### PR TITLE
Remove maven-ng-protractor from project dependencies since it is a plugin

### DIFF
--- a/trunk/workflow-manager/pom.xml
+++ b/trunk/workflow-manager/pom.xml
@@ -741,13 +741,6 @@
             <scope>test</scope>
         </dependency>
         <!-- / for testing HTTP callback -->
-
-        <dependency>
-            <groupId>com.github.greengerong</groupId>
-            <artifactId>maven-ng-protractor</artifactId>
-            <version>0.0.2</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <!-- NOTE: profile tags override non-profile tags -->


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/66)
<!-- Reviewable:end -->
