### PR TITLE
Use fewer services for system tests

### DIFF
--- a/trunk/mpf-install/pom.xml
+++ b/trunk/mpf-install/pom.xml
@@ -93,8 +93,10 @@
                             <target name="fix permissions because ant copy can't do this">
                                 <!-- Need to set maxparallel or else stress tests fail due to
                                 the argument list being too long. 
+                                maxparallel is the max number of arguments to chmod,
+                                not the number of chmod processes.
                                 See https://ant.apache.org/manual/Tasks/chmod.html -->
-                                <chmod perm="755" verbose="true" maxparallel="8">
+                                <chmod perm="755" verbose="true" maxparallel="100">
                                     <fileset dir="${basedir}/../install" includes="**/*"/>
                                 </chmod>
                             </target>

--- a/trunk/mpf-system-tests/src/test/resources/mpf-system-tests.properties
+++ b/trunk/mpf-system-tests/src/test/resources/mpf-system-tests.properties
@@ -34,4 +34,4 @@ data.template.dir=classpath:jenkins
 web.rest.protocol=http
 transport.guarantee=NONE
 
-startup.num.services.per.component=4
+startup.num.services.per.component=2


### PR DESCRIPTION
This should take care of all the Jenkins builds in #24.
These changes were tested in openmpf-stress builds 35 and 36.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/84)
<!-- Reviewable:end -->
