### PR TITLE
Make StartupComponentRegistrationServiceImpl ignore directories and files that don't end with .tar.gz.

### DIFF
--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/component/StartupComponentRegistrationServiceImpl.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/component/StartupComponentRegistrationServiceImpl.java
@@ -94,7 +94,11 @@ public class StartupComponentRegistrationServiceImpl implements StartupComponent
 			return;
 		}
 
-		List<Path> uploadedComponentPackages = listDirContent(_componentUploadDir);
+		List<Path> uploadedComponentPackages = listDirContent(_componentUploadDir).stream()
+				.filter(Files::isRegularFile)
+				.filter(p -> p.toString().endsWith(".tar.gz"))
+				.collect(toList());
+
 		List<RegisterComponentModel> allComponentEntries = _componentStateSvc.get();
 		Set<Path> unregisteredComponentPackages = getUnregisteredComponentPackages(uploadedComponentPackages,
 		                                                                           allComponentEntries);
@@ -281,7 +285,6 @@ public class StartupComponentRegistrationServiceImpl implements StartupComponent
 		}
 		try (Stream<Path> dirChildren = Files.list(dir)) {
 			return dirChildren.collect(toList());
-
 		}
 		catch (IOException e) {
 			throw new UncheckedIOException("Failed to list contents of: " + dir, e);

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestStartupComponentRegistrationService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestStartupComponentRegistrationService.java
@@ -82,6 +82,9 @@ public class TestStartupComponentRegistrationService {
 
 	@Before
 	public void init() throws IOException, ComponentRegistrationException {
+		_componentUploadDir.newFolder("test");
+		_componentUploadDir.newFile("bad.bad");
+
 		_mockPropertiesUtil = mock(PropertiesUtil.class);
 		when(_mockPropertiesUtil.getUploadedComponentsDirectory())
 				.thenReturn(_componentUploadDir.getRoot());


### PR DESCRIPTION
Issue #92

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/93)
<!-- Reviewable:end -->
