### PR TITLE
Fixed stress test assert comment.

### DIFF
--- a/trunk/mpf-system-tests/src/test/java/org/mitre/mpf/mst/TestSystemStress3.java
+++ b/trunk/mpf-system-tests/src/test/java/org/mitre/mpf/mst/TestSystemStress3.java
@@ -86,9 +86,9 @@ public class TestSystemStress3 extends TestSystemWithDefaultConfig {
         executor.shutdown();
         executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
-        Assert.assertEquals("Number of files to process={} doesn't match actual number of jobs run={} (one job/file)",
+        Assert.assertEquals("Number of files to process doesn't match actual number of jobs run (one job/file):",
                 files.size(), manyJobsNumFilesProcessed);
-        log.info("Successfully ran {} jobs for {} files, one file per job, without a hiccup",
+        log.info("Successfully ran {} jobs for {} files, one file per job.",
                 manyJobsNumFilesProcessed, files.size());
         log.info("Finished test runFaceOcvDetectImageManyJobs()");
     }


### PR DESCRIPTION
Post-fix, the failed output now looks like:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.mitre.mpf.mst.TestSystemStress3
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.713 sec <<< FAILURE!
runFaceOcvDetectImageManyJobs(org.mitre.mpf.mst.TestSystemStress3)  Time elapsed: 0.011 sec  <<< FAILURE!
java.lang.AssertionError: Number of files to process doesn't match actual number of jobs run (one job/file): expected:<100> but was:<10>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.mitre.mpf.mst.TestSystemStress3.runFaceOcvDetectImageManyJobs(TestSystemStress3.java:90)


Results :

Failed tests: 
  TestSystemStress3.runFaceOcvDetectImageManyJobs:90 Number of files to process doesn't match actual number of jobs run (one job/file): expected:<100> but was:<10>

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

[ERROR] There are test failures.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/360)
<!-- Reviewable:end -->
