### PR TITLE
fix bug: output object directory should be null for streaming job tha…

### DIFF
--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/StreamingJobController.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/StreamingJobController.java
@@ -306,7 +306,7 @@ public class StreamingJobController {
         StreamingJobRequest streamingJobRequest = mpfService.getStreamingJobRequest(jobId);
         if ( streamingJobRequest == null ) {
             // if the requested streaming job doesn't exist, it can't be marked for cancellation, so this is an error.
-            cancelResponse = new StreamingJobCancelResponse(jobId, "", doCleanup,
+            cancelResponse = new StreamingJobCancelResponse(jobId, null, doCleanup,
                 MpfResponse.RESPONSE_CODE_ERROR, "Streaming job with id " + jobId + " doesn't exist.");
         } else {
             try {


### PR DESCRIPTION
…t doesn't exist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/469)
<!-- Reviewable:end -->
