### PR TITLE
fixed swagger documentation that has streamUri listed twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,7 @@
         <xml-apis.xml-apis.version>1.4.01</xml-apis.xml-apis.version>
         <org.seleniumhq.selenium.selenium-java.version>2.53.0</org.seleniumhq.selenium.selenium-java.version>
         <maven.test.failure.ignore>true</maven.test.failure.ignore>
-      <!-- spring-framework upgraded to 4.2.8.RELEASE to accommodate SpringFox upgrade to 2.6.1 -->
-        <spring.framework.version>4.2.8.RELEASE</spring.framework.version>
+        <spring.framework.version>4.2.5.RELEASE</spring.framework.version>
         <hibernate.framework.version>5.0.8.Final</hibernate.framework.version>
         <hibernate.validator.version>5.2.4.Final</hibernate.validator.version>
         <javax.el.api.version>2.2.4</javax.el.api.version>
@@ -127,8 +126,7 @@
 		<xstream.version>1.4.8</xstream.version>
 		<common.beanutils.version>1.9.2</common.beanutils.version>
 		<mysql.connector.java.version>5.1.36</mysql.connector.java.version>
-      <!-- joda-time upgraded to 2.9.4 to accommodate SpringFox upgrade to 2.6.1 -->
-		<joda.time.version>2.9.4</joda.time.version>
+		<joda.time.version>2.8.2</joda.time.version>
 		<joda.time.hibernate.version>1.4</joda.time.hibernate.version>
 		<jadira.usertype.core.version>5.0.0.GA</jadira.usertype.core.version>
 		<bonecp.spring.version>0.8.0.RELEASE</bonecp.spring.version>
@@ -145,12 +143,7 @@
 		<velocity.version>1.7</velocity.version>
 		<google.protobuf.version>2.6.1</google.protobuf.version>
 		<janino.version>2.7.8</janino.version>
-      <!-- upgraded SpringFox to 2.6.1 to allow for using @ApiModelProperty annotation hidden attribute. Hidden attribute was -->
-      <!-- supported starting in SpringFox 2.6. -->
-      <!-- TODO Does SpringFox 2.6.1 support disabling of validation via an external server? (r.e. comment below) -->
-      <!-- According to the release notes at https://github.com/springfox/springfox/blob/master/docs/release-notes.md -->
-      <!-- Bug #951 was fixed in SpringFox 2.3. so the upgrade to SpringFox 2.6.1 should be ok - but how to test this? -->
-		<springfox.swagger.version>2.6.1</springfox.swagger.version>
+		<springfox.swagger.version>2.1.1</springfox.swagger.version>
     <!-- this is an older version of SpringFox, but it is the only version that enables us to disable validation via an external server; -->
     <!-- for more information, see https://github.com/springfox/springfox/issues/951.  Version 2.3 of SpringFox is supposed to bring     -->
     <!-- this functionality back, but as of mpf release 4, this is not yet ready, so we're forced to use 2.1.1 -->

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,8 @@
         <xml-apis.xml-apis.version>1.4.01</xml-apis.xml-apis.version>
         <org.seleniumhq.selenium.selenium-java.version>2.53.0</org.seleniumhq.selenium.selenium-java.version>
         <maven.test.failure.ignore>true</maven.test.failure.ignore>
-        <spring.framework.version>4.2.5.RELEASE</spring.framework.version>
+      <!-- spring-framework upgraded to 4.2.8.RELEASE to accommodate SpringFox upgrade to 2.6.1 -->
+        <spring.framework.version>4.2.8.RELEASE</spring.framework.version>
         <hibernate.framework.version>5.0.8.Final</hibernate.framework.version>
         <hibernate.validator.version>5.2.4.Final</hibernate.validator.version>
         <javax.el.api.version>2.2.4</javax.el.api.version>
@@ -126,7 +127,8 @@
 		<xstream.version>1.4.8</xstream.version>
 		<common.beanutils.version>1.9.2</common.beanutils.version>
 		<mysql.connector.java.version>5.1.36</mysql.connector.java.version>
-		<joda.time.version>2.8.2</joda.time.version>
+      <!-- joda-time upgraded to 2.9.4 to accommodate SpringFox upgrade to 2.6.1 -->
+		<joda.time.version>2.9.4</joda.time.version>
 		<joda.time.hibernate.version>1.4</joda.time.hibernate.version>
 		<jadira.usertype.core.version>5.0.0.GA</jadira.usertype.core.version>
 		<bonecp.spring.version>0.8.0.RELEASE</bonecp.spring.version>
@@ -143,7 +145,12 @@
 		<velocity.version>1.7</velocity.version>
 		<google.protobuf.version>2.6.1</google.protobuf.version>
 		<janino.version>2.7.8</janino.version>
-		<springfox.swagger.version>2.1.1</springfox.swagger.version>
+      <!-- upgraded SpringFox to 2.6.1 to allow for using @ApiModelProperty annotation hidden attribute. Hidden attribute was -->
+      <!-- supported starting in SpringFox 2.6. -->
+      <!-- TODO Does SpringFox 2.6.1 support disabling of validation via an external server? (r.e. comment below) -->
+      <!-- According to the release notes at https://github.com/springfox/springfox/blob/master/docs/release-notes.md -->
+      <!-- Bug #951 was fixed in SpringFox 2.3. so the upgrade to SpringFox 2.6.1 should be ok - but how to test this? -->
+		<springfox.swagger.version>2.6.1</springfox.swagger.version>
     <!-- this is an older version of SpringFox, but it is the only version that enables us to disable validation via an external server; -->
     <!-- for more information, see https://github.com/springfox/springfox/issues/951.  Version 2.3 of SpringFox is supposed to bring     -->
     <!-- this functionality back, but as of mpf release 4, this is not yet ready, so we're forced to use 2.1.1 -->

--- a/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/StreamingJobCreationRequest.java
+++ b/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/StreamingJobCreationRequest.java
@@ -26,9 +26,15 @@
 
 package org.mitre.mpf.rest.api;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.Map;
 
+// swagger includes
+@Api(value = "streaming-jobs")
+@ApiModel(description="StreamingJobCreationRequest model")
 public class StreamingJobCreationRequest {
 	private Map<String, String> jobProperties = new HashMap<>();
 	private Map<String, Map<String,String>> algorithmProperties = new HashMap<>();
@@ -52,6 +58,7 @@ public class StreamingJobCreationRequest {
 		return stream;
 	}
 	public void setStream(JobCreationStreamData streamData) { this.stream = streamData; }
+	@ApiModelProperty(hidden = true)
 	public String getStreamUri() { return stream.getStreamUri(); }
 
 	public Map<String, String> getMediaProperties() { return stream.getMediaProperties(); }

--- a/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/StreamingJobCreationRequest.java
+++ b/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/StreamingJobCreationRequest.java
@@ -26,15 +26,9 @@
 
 package org.mitre.mpf.rest.api;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.Map;
 
-// swagger includes
-@Api(value = "streaming-jobs")
-@ApiModel(description="StreamingJobCreationRequest model")
 public class StreamingJobCreationRequest {
 	private Map<String, String> jobProperties = new HashMap<>();
 	private Map<String, Map<String,String>> algorithmProperties = new HashMap<>();
@@ -58,8 +52,6 @@ public class StreamingJobCreationRequest {
 		return stream;
 	}
 	public void setStream(JobCreationStreamData streamData) { this.stream = streamData; }
-	@ApiModelProperty(hidden = true)
-	public String getStreamUri() { return stream.getStreamUri(); }
 
 	public Map<String, String> getMediaProperties() { return stream.getMediaProperties(); }
 	public int getSegmentSize() {

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/StreamingJobController.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/StreamingJobController.java
@@ -202,11 +202,11 @@ public class StreamingJobController {
             if ( !streamingJobCreationRequest.isValidRequest() ) {
                 // The streaming job failed the API syntax check, the job request is malformed. Reject the job and send an error response.
                 return createStreamingJobCreationErrorResponse(streamingJobCreationRequest.getExternalId(), "malformed request");
-            } else if ( !StreamResource.isSupportedUriScheme(streamingJobCreationRequest.getStreamUri()) ) {
+            } else if ( !StreamResource.isSupportedUriScheme(streamingJobCreationRequest.getStream().getStreamUri()) ) {
                 // The streaming job failed the check for supported stream protocol check, so OpenMPF can't process the requested stream URI.
                 // Reject the job and send an error response.
                 return createStreamingJobCreationErrorResponse(streamingJobCreationRequest.getExternalId(),
-                    "malformed or unsupported stream URI: " + streamingJobCreationRequest.getStreamUri());
+                    "malformed or unsupported stream URI: " + streamingJobCreationRequest.getStream().getStreamUri());
             } else if ( !pipelineService.pipelineSupportsStreaming(streamingJobCreationRequest.getPipelineName()) ) {
                 // The streaming job failed the pipeline check. The requested pipeline doesn't support streaming.
                 // Reject the job and send an error response.
@@ -223,7 +223,7 @@ public class StreamingJobController {
                 }
 
                 JsonStreamingInputObject json_stream = new JsonStreamingInputObject(
-                        streamingJobCreationRequest.getStreamUri(),
+                        streamingJobCreationRequest.getStream().getStreamUri(),
                         streamingJobCreationRequest.getSegmentSize(),
                         streamingJobCreationRequest.getMediaProperties());
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/532)
<!-- Reviewable:end -->
