### PR TITLE
Fixed issue where services would not start on an auto-configured node because it was not in the Running state.

### DIFF
--- a/trunk/node-manager/src/main/java/org/mitre/mpf/nms/ChannelReceiver.java
+++ b/trunk/node-manager/src/main/java/org/mitre/mpf/nms/ChannelReceiver.java
@@ -157,12 +157,13 @@ public abstract class ChannelReceiver extends ReceiverAdapter {
                             LOG.warn("New node-manager is online that wasn't preconfigured. Treating as a spare node.");
                         }
                     }
+                    boolean isNew = !mgr.isAlive(); // if this is a new node-manager, it hasn't been active until now
+                    mgr.setLastKnownState(NodeManagerConstants.States.Running);
                     // Issue the callback
-                    if (notifier != null && !mgr.isAlive()) {
+                    if (notifier != null && isNew) {
                         // Call this whenever a node-manager becomes available to launch services.
                         notifier.newManager(mgr.getHostname());
                     }
-                    mgr.setLastKnownState(NodeManagerConstants.States.Running);
                     synchronized (nodeTable) {
                         nodeTable.put(mgrHost, mgr);
                     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/773)
<!-- Reviewable:end -->
