### PR TITLE
Change local path for tmp media and change base directory

### DIFF
--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/MediaController.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/MediaController.java
@@ -32,7 +32,6 @@ import org.mitre.mpf.mvc.MpfServiceException;
 import org.mitre.mpf.wfm.WfmProcessingException;
 import org.mitre.mpf.wfm.service.ServerMediaService;
 import org.mitre.mpf.wfm.util.IoUtils;
-import org.mitre.mpf.wfm.util.MediaTypeUtils;
 import org.mitre.mpf.wfm.util.PropertiesUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,10 +91,10 @@ public class MediaController {
 			log.error(err);
 			throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR,err);
 		};
-		String webTmpDirectory = propertiesUtil.getRemoteMediaCacheDirectory().getAbsolutePath();
+		String remoteMediaDirectory = propertiesUtil.getRemoteMediaDirectory().getAbsolutePath();
 		//verify the desired path
 		File desiredPath = new File(desiredpath);
-		if (!desiredPath.exists() || !desiredPath.getAbsolutePath().startsWith(webTmpDirectory)) {//make sure it is valid and within the remote-media directory
+		if (!desiredPath.exists() || !desiredPath.getAbsolutePath().startsWith(remoteMediaDirectory)) {//make sure it is valid and within the remote-media directory
 			log.error(err);
 			throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, err);
 		}
@@ -195,12 +194,12 @@ public class MediaController {
 		String desiredPathParam = request.getParameter("desiredpath");
 		log.debug("Upload to Directory:"+desiredPathParam);
 		if(desiredPathParam == null) return new ResponseEntity<>("{\"error\":\"desiredPathParam Empty\"}", HttpStatus.INTERNAL_SERVER_ERROR);
-		String webTmpDirectory = propertiesUtil.getRemoteMediaCacheDirectory().getAbsolutePath();
+		String remoteMediaDirectory = propertiesUtil.getRemoteMediaDirectory().getAbsolutePath();
 
 		try {
 			//verify the desired path
 			File desiredPath = new File(desiredPathParam);
-			if(!desiredPath.exists() || !desiredPath.getAbsolutePath().startsWith(webTmpDirectory)) {//make sure it is valid and within the remote-media directory
+			if(!desiredPath.exists() || !desiredPath.getAbsolutePath().startsWith(remoteMediaDirectory)) {//make sure it is valid and within the remote-media directory
 				String err = "Error with desired path: "+desiredPathParam;
 				log.error(err);
 				return new ResponseEntity<>("{\"error\":\"" + err + "\"}", HttpStatus.INTERNAL_SERVER_ERROR);
@@ -263,7 +262,7 @@ public class MediaController {
 		if(serverpath == null ) {
 			return new ResponseEntity<>("{\"error\":\"invalid parameter\"}", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
-		String uploadPath =  propertiesUtil.getRemoteMediaCacheDirectory().getAbsolutePath();
+		String uploadPath =  propertiesUtil.getRemoteMediaDirectory().getAbsolutePath();
 		log.info("CreateRemoteMediaDirectory: ServerPath:" + serverpath + " uploadPath:" + uploadPath);
 		if(serverpath.startsWith(uploadPath)){
 			File dir = new File(serverpath);

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/ServerMediaController.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/ServerMediaController.java
@@ -120,9 +120,9 @@ public class ServerMediaController {
 
         // if useUploadRoot is set it will take precedence over nodeFullPath
         DirectoryTreeNode node = serverMediaService.getAllDirectories(nodePath, request.getServletContext(), useCache,
-                                                                      propertiesUtil.getRemoteMediaCacheDirectory().getAbsolutePath());
+                                                                      propertiesUtil.getRemoteMediaDirectory().getAbsolutePath());
         if(useUploadRoot != null && useUploadRoot){
-            node =  DirectoryTreeNode.find(node, propertiesUtil.getRemoteMediaCacheDirectory().getAbsolutePath());
+            node =  DirectoryTreeNode.find(node, propertiesUtil.getRemoteMediaDirectory().getAbsolutePath());
         }
 
         return node;

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/mediaretrieval/RemoteMediaProcessor.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/mediaretrieval/RemoteMediaProcessor.java
@@ -89,6 +89,7 @@ public class RemoteMediaProcessor extends WfmProcessor {
                     else {
                         downloadFile(jobId, transientMedia);
                     }
+                    transientMedia.getLocalPath().toFile().deleteOnExit();
                 }
                 catch (StorageException e) {
                     String message = handleMediaRetrievalException(

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/data/InProgressBatchJobsService.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/data/InProgressBatchJobsService.java
@@ -232,7 +232,7 @@ public class InProgressBatchJobsService {
                 errorMessage = checkForLocalFileError(localPath);
             }
             else {
-                localPath = _propertiesUtil.getRemoteMediaCacheDirectory()
+                localPath = _propertiesUtil.getTemporaryMediaDirectory()
                         .toPath()
                         .resolve(UUID.randomUUID().toString())
                         .toAbsolutePath();

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/ServerMediaServiceImpl.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/ServerMediaServiceImpl.java
@@ -130,7 +130,7 @@ public class ServerMediaServiceImpl implements ServerMediaService {
 
 	public List<ServerMediaFile> getFiles(String dirPath, ServletContext context, boolean useCache, boolean recurse) {
 		DirectoryTreeNode node = getAllDirectories(propertiesUtil.getServerMediaTreeRoot(), context,
-				useCache, propertiesUtil.getRemoteMediaCacheDirectory().getAbsolutePath());
+				useCache, propertiesUtil.getRemoteMediaDirectory().getAbsolutePath());
 		node = DirectoryTreeNode.find(node, dirPath);
 		return getFiles(node, context, useCache, recurse);
 	}

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
@@ -115,7 +115,7 @@ public class PropertiesUtil {
         markupDirectory = createOrFail(share, "markup", permissions);
         outputObjectsDirectory = createOrFail(share, "output-objects", permissions);
         remoteMediaDirectory = createOrFail(share, "remote-media", permissions);
-        temporaryMediaDirectory = createOrFail(share, "tmp", permissions);
+        temporaryMediaDirectory = createOrClear(share, "tmp", permissions);
         uploadedComponentsDirectory = createOrFail(share, getComponentUploadDirName(), permissions);
         createOrFail(getPluginDeploymentPath(), "",
                 EnumSet.of(
@@ -163,6 +163,18 @@ public class PropertiesUtil {
         }
 
         return child.toAbsolutePath().toFile();
+    }
+
+    private static File createOrClear(Path parent, String subdirectory, Set<PosixFilePermission> permissions)
+            throws IOException, WfmProcessingException {
+        Path child = parent.resolve(subdirectory);
+        if ( Files.exists(child) ) {
+            Files.walk(child)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
+        return createOrFail(parent, subdirectory, permissions);
     }
 
     public String lookup(String propertyName) {

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
@@ -29,6 +29,7 @@ package org.mitre.mpf.wfm.util;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
+import com.google.common.io.MoreFiles;
 import org.apache.commons.configuration2.ImmutableConfiguration;
 import org.apache.commons.configuration2.ex.ConversionException;
 import org.apache.commons.io.IOUtils;
@@ -169,12 +170,11 @@ public class PropertiesUtil {
             throws IOException, WfmProcessingException {
         Path child = parent.resolve(subdirectory);
         if ( Files.exists(child) ) {
-            Files.walk(child)
-                    .sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(File::delete);
+            MoreFiles.deleteDirectoryContents(child);
+            return child.toAbsolutePath().toFile();
+        } else {
+            return createOrFail(parent, subdirectory, permissions);
         }
-        return createOrFail(parent, subdirectory, permissions);
     }
 
     public String lookup(String propertyName) {

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
@@ -114,7 +114,8 @@ public class PropertiesUtil {
         artifactsDirectory = createOrFail(share, "artifacts", permissions);
         markupDirectory = createOrFail(share, "markup", permissions);
         outputObjectsDirectory = createOrFail(share, "output-objects", permissions);
-        remoteMediaCacheDirectory = createOrFail(share, "remote-media", permissions);
+        remoteMediaDirectory = createOrFail(share, "remote-media", permissions);
+        temporaryMediaDirectory = createOrFail(share, "tmp", permissions);
         uploadedComponentsDirectory = createOrFail(share, getComponentUploadDirName(), permissions);
         createOrFail(getPluginDeploymentPath(), "",
                 EnumSet.of(
@@ -134,7 +135,8 @@ public class PropertiesUtil {
         log.debug("Artifacts Directory = {}", artifactsDirectory);
         log.debug("Markup Directory = {}", markupDirectory);
         log.debug("Output Objects Directory = {}", outputObjectsDirectory);
-        log.debug("Remote Media Cache Directory = {}", remoteMediaCacheDirectory);
+        log.debug("Remote Media Directory = {}", remoteMediaDirectory);
+        log.debug("Temporary Media Directory = {}", temporaryMediaDirectory);
         log.debug("Uploaded Components Directory = {}", uploadedComponentsDirectory);
     }
 
@@ -344,8 +346,11 @@ public class PropertiesUtil {
         return path;
     }
 
-    private File remoteMediaCacheDirectory;
-    public File getRemoteMediaCacheDirectory() { return remoteMediaCacheDirectory; }
+    private File remoteMediaDirectory;
+    public File getRemoteMediaDirectory() { return remoteMediaDirectory; }
+
+    private File temporaryMediaDirectory;
+    public File getTemporaryMediaDirectory() { return temporaryMediaDirectory; }
 
     private File markupDirectory;
     public File getMarkupDirectory() { return markupDirectory; }

--- a/trunk/workflow-manager/src/main/resources/properties/mpf.properties
+++ b/trunk/workflow-manager/src/main/resources/properties/mpf.properties
@@ -211,7 +211,7 @@ web.session.timeout=30
 
 #top-level path to retrieve media (webServerMediaTreeBase)
 # for normal users, $HOME should be the same as /home/${MPF_USER}, but not always
-web.server.media.tree.base=${env:MPF_HOME}/share
+web.server.media.tree.base=${env:MPF_HOME}/share/remote-media
 
 #the amount of files that can be submitted to the server for upload from "Browse" selection
 web.max.file.upload.cnt=2500

--- a/trunk/workflow-manager/src/main/webapp/WEB-INF/html/server_media/layout.html
+++ b/trunk/workflow-manager/src/main/webapp/WEB-INF/html/server_media/layout.html
@@ -41,13 +41,13 @@
                 </div>
                 <div class="row" id="directoryListDivBtns" >
                     <div style="display:inline-block;">
-                        <div class="btn btn-success btn-sm " id="newfolder_btn" ng-disabled="disableBtns" data-toggle="modal" data-target="#newFolderModal" title="Create New Folder">
+                        <div class="btn btn-success btn-sm " id="newfolder_btn" data-toggle="modal" data-target="#newFolderModal" title="Create New Folder">
                             <span class="glyphicon glyphicon-folder-open"></span>
                         </div>
-                        <div class="btn btn-success btn-sm btn-add fileinput-button" id="addFiles_btn" ng-disabled="disableBtns" title="Add Local Files">
+                        <div class="btn btn-success btn-sm btn-add fileinput-button" id="addFiles_btn" title="Add Local Files">
                             <span class="fa fa-upload"></span>
                         </div>
-                        <div class="btn btn-success btn-sm btn-upload " id="urlUpload_btn_btn" ng-click="uploadURLBtn()" ng-disabled="disableBtns" title="Upload from URL">
+                        <div class="btn btn-success btn-sm btn-upload " id="urlUpload_btn_btn" ng-click="uploadURLBtn()" title="Upload from URL">
                             <span class="fa fa-cloud-upload"></span>
                         </div>
                         <div class="btn btn-sm btn-warning" ng-click="refreshRequest()" title="Refresh Directories">

--- a/trunk/workflow-manager/src/main/webapp/WEB-INF/html/server_media/layout.html
+++ b/trunk/workflow-manager/src/main/webapp/WEB-INF/html/server_media/layout.html
@@ -24,7 +24,7 @@
     limitations under the License.
 -->
 <div class="page-header text-center">
-    <h3>Create Job</h3> <page-info>Select a directory to view its files. Checking a directory in the tree will add all the files and directories beneath it. Select the remote-media directory, or a subdirectory, before creating a folder or uploading media.</page-info>
+    <h3>Create Job</h3> <page-info>Select a directory to view its files. Checking a directory in the tree will add all the files and directories beneath it.</page-info>
 </div>
 
 <div class="row fileManager" id="fileManager" style="height:90%;">

--- a/trunk/workflow-manager/src/main/webapp/resources/mytheme/js/controllers/ServerMediaCtrl.js
+++ b/trunk/workflow-manager/src/main/webapp/resources/mytheme/js/controllers/ServerMediaCtrl.js
@@ -45,7 +45,6 @@
             var removeAll = false;
             var directoryMap = {};
             var allowUpload = true;
-            $scope.disableBtns = true;
             var successfulUploads = 0;
             var cancelledUploads = 0;
             var modalShow = false;
@@ -75,7 +74,6 @@
                 $scope.selectedPipelineServer = {};//selected pipeline
                 fileList = [];//current list of files for the selected folder
                 $scope.useUploadView = false;
-                $scope.disableBtns = true;
                 if (!$scope.$$phase) $scope.$apply();
 
                 MediaService.getMaxFileUploadCnt().then(function (max) {
@@ -139,11 +137,6 @@
                 selectedNode = node;
                 $("#directoryTreeview").treeview('selectNode', [node.nodeId, {silent: true}]);
                 $("#breadcrumb").html(node.fullPath);
-                if (node.canUpload) {
-                    $scope.disableBtns = false;
-                } else {
-                    $scope.disableBtns = true;
-                }
                 if (!$scope.$$phase) $scope.$apply();
                 renderFileList();
             };
@@ -248,8 +241,6 @@
                 });
                 $('#directoryTreeview').treeview('selectNode', selectedNode.nodeId);
                 $('#directoryTreeview').treeview('revealNode', [selectedNode.nodeId, {silent: true}]);
-
-                $scope.disableBtns = true;
 
                 //check nodes if necessary
                 updateTreeChecks();
@@ -934,21 +925,18 @@
                     var parent = selectedNode;
                     var path = selectedNode.fullPath + "/" + $scope.newfolder;
                     $log.debug("Adding new folder", path);
-                    $scope.disableBtns = true;
                     if (!$scope.$$phase) $scope.$apply();
                     MediaService.createDirectory(path).then(function (data) {
                         var folder = $scope.newfolder;
                         $scope.newfolder = "";
                         reloadTree(function () {
                             selectFolder(parent.nodeId, folder);
-                            $scope.disableBtns = false;
                             if (!$scope.$$phase) $scope.$apply();
                         });
                     }, function (e) {
                         console.log("error", e);
                         NotificationSvc.error("Cannot create folder '" + $scope.newfolder + "':" + e);
                         $scope.newfolder = "";
-                        $scope.disableBtns = false;
                         if (!$scope.$$phase) $scope.$apply();
                     });
                 }


### PR DESCRIPTION
This fix should lessen the effects of the file index memory leak by setting the media tree base to the `remote-media` directory, as well as store temporary downloaded media in a `tmp` directory outside of `remote-media`.

https://github.com/openmpf/openmpf/issues/899

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/903)
<!-- Reviewable:end -->
