### PR TITLE
Increase Cargo Start Timeout

### DIFF
--- a/trunk/workflow-manager/pom.xml
+++ b/trunk/workflow-manager/pom.xml
@@ -1053,6 +1053,9 @@
                         <goals>
                             <goal>start</goal>
                         </goals>
+                        <configuration>
+                            <timeout>600000</timeout>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>stop-tc</id>

--- a/trunk/workflow-manager/pom.xml
+++ b/trunk/workflow-manager/pom.xml
@@ -1020,7 +1020,7 @@
                             <web.rest.protocol>http</web.rest.protocol>
                             <transport.guarantee>NONE</transport.guarantee>
                         </systemProperties>
-                        <timeout>600000</timeout>
+                        <timeout>3600000</timeout>
                     </container>
                     <configuration>
                         <type>standalone</type>
@@ -1054,9 +1054,6 @@
                         <goals>
                             <goal>start</goal>
                         </goals>
-                        <configuration>
-                            <timeout>600000</timeout>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>stop-tc</id>

--- a/trunk/workflow-manager/pom.xml
+++ b/trunk/workflow-manager/pom.xml
@@ -1020,6 +1020,7 @@
                             <web.rest.protocol>http</web.rest.protocol>
                             <transport.guarantee>NONE</transport.guarantee>
                         </systemProperties>
+                        <timeout>600000</timeout>
                     </container>
                     <configuration>
                         <type>standalone</type>


### PR DESCRIPTION
This error was coming up in the Jenkins builds:
```
[ERROR] Failed to execute goal org.codehaus.cargo:cargo-maven2-plugin:1.4.8:start (start-tc) on project mpf-workflowManager: Execution start-tc of goal org.codehaus.cargo:cargo-maven2-plugin:1.4.8:start failed: Deployable [http://localhost:8181/cargocpc/index.html] failed to finish deploying within the timeout period [120000]. The Deployable state is thus unknown. -> [Help 1]
```

To fix this we should increase the timeout from the default of 2 minutes, to 10 minutes, which is what the Ansible deployment use to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/950)
<!-- Reviewable:end -->
