### PR TITLE
Fix use of match filter for Ansbile 2.9.

### DIFF
--- a/trunk/ansible/install/ansible/roles/child/tasks/compdeploy.yml
+++ b/trunk/ansible/install/ansible/roles/child/tasks/compdeploy.yml
@@ -75,7 +75,7 @@
     - name: Get the component top level directory
       set_fact:
         component_tld: "{{ component_tld|default([])|union([{'tld': item}]) }}"
-      when: "{{ item | match(component_tld_regex) }}"
+      when: item is match(component_tld_regex)
       with_items: "{{ component_contents.stdout_lines }}"
       register: tld_r
 


### PR DESCRIPTION
From [here](https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters):

> Using Ansible-provided jinja tests as filters will be removed in Ansible 2.9.
>
> Prior to Ansible 2.5, jinja tests included within Ansible were most often used as filters. The large difference in use is that filters are referenced as `variable | filter_name` where as jinja tests are refereced as `variable is test_name`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/1007)
<!-- Reviewable:end -->
