### PR TITLE
Fix for bug reported in issue 1097

### DIFF
--- a/trunk/interop/src/main/java/org/mitre/mpf/interop/JsonDetectionOutputObject.java
+++ b/trunk/interop/src/main/java/org/mitre/mpf/interop/JsonDetectionOutputObject.java
@@ -88,8 +88,9 @@ public class JsonDetectionOutputObject implements Comparable<JsonDetectionOutput
 
 	@JsonProperty("artifactExtractionStatus")
 	@JsonPropertyDescription("A status code indicating if an artifact was created for this detection.")
-	private final String artifactExtractionStatus;
+	private String artifactExtractionStatus;
 	public String getArtifactExtractionStatus() { return artifactExtractionStatus; }
+	public void setArtifactExtractionStatus(String status) { artifactExtractionStatus = status; }
 
 
 	@JsonCreator

--- a/trunk/mpf-system-tests/src/test/java/org/mitre/mpf/mst/TestSystemOnDiff.java
+++ b/trunk/mpf-system-tests/src/test/java/org/mitre/mpf/mst/TestSystemOnDiff.java
@@ -79,6 +79,7 @@ public class TestSystemOnDiff extends TestSystemWithDefaultConfig {
         Map<String, String> jobProperties = new HashMap<>();
         jobProperties.put("OUTPUT_ARTIFACTS_AND_EXEMPLARS_ONLY", "true");
         jobProperties.put("ARTIFACT_EXTRACTION_POLICY", "ALL_DETECTIONS");
+        jobProperties.put("ARTIFACT_EXTRACTION_POLICY_CROPPING", "false");
         List<JobCreationMediaData> media = toMediaObjectList(ioUtils.findFile("/samples/face/video_01.mp4"));
 
         long jobId = runPipelineOnMedia("OCV FACE DETECTION PIPELINE", jobProperties, media);

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/detection/artifactextraction/ArtifactExtractionProcessor.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/detection/artifactextraction/ArtifactExtractionProcessor.java
@@ -27,8 +27,6 @@
 package org.mitre.mpf.wfm.camel.operations.detection.artifactextraction;
 
 import org.apache.camel.Exchange;
-import org.apache.commons.lang3.tuple.MutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.mitre.mpf.interop.JsonDetectionOutputObject;
 import org.mitre.mpf.wfm.camel.WfmProcessor;
 import org.mitre.mpf.wfm.data.InProgressBatchJobsService;

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/detection/artifactextraction/ArtifactExtractionProcessor.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/detection/artifactextraction/ArtifactExtractionProcessor.java
@@ -27,6 +27,8 @@
 package org.mitre.mpf.wfm.camel.operations.detection.artifactextraction;
 
 import org.apache.camel.Exchange;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.mitre.mpf.interop.JsonDetectionOutputObject;
 import org.mitre.mpf.wfm.camel.WfmProcessor;
 import org.mitre.mpf.wfm.data.InProgressBatchJobsService;
@@ -116,40 +118,56 @@ public class ArtifactExtractionProcessor extends WfmProcessor {
         }
         SortedSet<Track> jobTracks = _inProgressBatchJobs.getTracks(request.getJobId(), request.getMediaId(),
                 request.getTaskIndex(), request.getActionIndex());
-        for (Table.Cell<Integer, Integer, URI> entry : trackAndFrameToUri.cellSet()) {
-            URI uri = entry.getValue();
-            if (request.getCroppingFlag()) {
+        // Set the status for the requested detections. If any were requested, but were not included in the extraction output,
+        // they will be reported as missing frames.
+        trackAndFrameToUri.cellSet().stream()
+                .forEach(e -> request.getExtractionsMap().get(e.getColumnKey()).get(e.getRowKey()).setArtifactExtractionStatus("COMPLETED"));
+
+        if (request.getCroppingFlag()) {
+            for (Table.Cell<Integer, Integer, URI> entry : trackAndFrameToUri.cellSet()) {
+                URI uri = entry.getValue();
                 jobTracks.stream().filter(t -> t.getArtifactExtractionTrackIndex() == entry.getRowKey())
-                                  .flatMap(t -> t.getDetections().stream())
-                                  .filter(d -> d.getMediaOffsetFrame() == entry.getColumnKey())
-                                  .forEach( d -> setStatus(d, uri));
+                        .flatMap(t -> t.getDetections().stream())
+                        .filter(d -> d.getMediaOffsetFrame() == entry.getColumnKey())
+                        .forEach(d -> setStatus(d, uri));
             }
-            else {
-                for (Integer frame : trackAndFrameToUri.columnKeySet()) {
-                    jobTracks.stream().flatMap(t -> t.getDetections().stream())
-                                      .filter(d -> frame.equals(d.getMediaOffsetFrame()))
-                                      .forEach(d -> setStatus(d, uri));
-                }
+        }
+        else {
+            for (Integer frame : trackAndFrameToUri.columnKeySet()) {
+                // When we are not cropping, the track number is a don't care; it is set to 0 in the frame extraction code.
+                URI uri = trackAndFrameToUri.get(0, frame);
+                jobTracks.stream().flatMap(t -> t.getDetections().stream())
+                        .filter(d -> d.getMediaOffsetFrame() == frame)
+                        .forEach(d -> setStatus(d, uri));
             }
         }
 
-        SortedSet<Integer> missingFrames = findMissingFrames(request);
+        _inProgressBatchJobs.setTracks(request.getJobId(), request.getMediaId(),
+                                       request.getTaskIndex(), request.getActionIndex(), jobTracks);
+
+        SortedSet<Integer> missingFrames = findMissingFrames(jobTracks, request);
         if (!missingFrames.isEmpty()) {
             _inProgressBatchJobs.setJobStatus(request.getJobId(), BatchJobStatusType.IN_PROGRESS_ERRORS);
             _inProgressBatchJobs.addMediaError(request.getJobId(), request.getMediaId(),
                     "Error extracting artifact(s) from frame(s): " + missingFrames);
         }
-        _inProgressBatchJobs.setTracks(request.getJobId(), request.getMediaId(),
-                                       request.getTaskIndex(), request.getActionIndex(), jobTracks);
     }
 
-    private SortedSet<Integer> findMissingFrames(ArtifactExtractionRequest request) {
+    private SortedSet<Integer> findMissingFrames(SortedSet<Track> jobTracks, ArtifactExtractionRequest request) {
 
-        return request.getExtractionsMap().values().stream()
-                                   .flatMap(v -> v.values().stream())
-                                   .filter(d ->(d.getArtifactExtractionStatus() == ArtifactExtractionStatus.FAILED.name()) ||
-                                    (d.getArtifactExtractionStatus() == ArtifactExtractionStatus.REQUESTED.name()))
-                                   .map(JsonDetectionOutputObject::getOffsetFrame).collect(toCollection(TreeSet::new));
+        // Check for frames in the tracks that failed.
+        SortedSet<Integer> missingFrames = jobTracks.stream()
+                                   .flatMap(t -> t.getDetections().stream())
+                                   .filter(d ->(d.getArtifactExtractionStatus() == ArtifactExtractionStatus.FAILED))
+                                   .map(Detection::getMediaOffsetFrame).collect(toCollection(TreeSet::new));
+        // Check for frames that were supposed to be extracted but weren't
+        SortedSet<Integer> missingRequestFrames = request.getExtractionsMap().values().stream()
+                .flatMap(v -> v.values().stream())
+                .filter(d -> d.getArtifactExtractionStatus().equals(ArtifactExtractionStatus.REQUESTED.name()))
+                .map(JsonDetectionOutputObject::getOffsetFrame).collect(toCollection(TreeSet::new));
+        missingFrames.addAll(missingRequestFrames);
+
+        return missingFrames;
     }
 
     private void handleException(ArtifactExtractionRequest request, IOException e) {
@@ -159,7 +177,8 @@ public class ArtifactExtractionProcessor extends WfmProcessor {
                         + "for this medium will NOT have an associated artifact.",
                 request.getJobId(), request.getTaskIndex(), request.getMediaId(), e);
         _inProgressBatchJobs.setJobStatus(request.getJobId(), BatchJobStatusType.IN_PROGRESS_ERRORS);
-        SortedSet<Integer> missingFrames = findMissingFrames(request);
+        SortedSet<Integer> missingFrames = findMissingFrames(_inProgressBatchJobs.getTracks(request.getJobId(), request.getMediaId(),
+                request.getTaskIndex(), request.getActionIndex()), request);
         if (!missingFrames.isEmpty()) {
             _inProgressBatchJobs.addMediaError(request.getJobId(), request.getMediaId(),
                     "Error extracting artifact(s) from frame(s): " + missingFrames);

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/detection/artifactextraction/ArtifactExtractionSplitterImpl.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/detection/artifactextraction/ArtifactExtractionSplitterImpl.java
@@ -200,7 +200,10 @@ public class ArtifactExtractionSplitterImpl extends WfmSplitter {
                 }
                 default:
             }
-            trackIndex++;
+
+            // If we are not going to crop extracted artifacts, then all we need to do is collect frame numbers; the trackIndex is
+            // a don't care. This simplifies the process of setting the artifact extraction status later.
+            if (request.getCroppingFlag()) trackIndex++;
         }
         _inProgressBatchJobs.setTracks(request.getJobId(), request.getMediaId(), request.getTaskIndex(), request.getActionIndex(), tracks);
 


### PR DESCRIPTION
The findMissingFrames function had several problems with it, were all masked by the fact that "==" was used to compare strings instead of .equals().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/1099)
<!-- Reviewable:end -->
