### PR TITLE
Modify job id to support load balancing

### DIFF
--- a/trunk/interop/src/main/java/org/mitre/mpf/interop/JsonCallbackBody.java
+++ b/trunk/interop/src/main/java/org/mitre/mpf/interop/JsonCallbackBody.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class JsonCallbackBody {
-    /** The internal identifier assigned to this job by MPF. */
+    /** The identifier assigned to this job by MPF. */
     private final String _jobId;
     public String getJobId() { return _jobId; }
 

--- a/trunk/interop/src/main/java/org/mitre/mpf/interop/JsonCallbackBody.java
+++ b/trunk/interop/src/main/java/org/mitre/mpf/interop/JsonCallbackBody.java
@@ -31,8 +31,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class JsonCallbackBody {
     /** The internal identifier assigned to this job by MPF. */
-    private final long _jobId;
-    public long getJobId() { return _jobId; }
+    private final String _jobId;
+    public String getJobId() { return _jobId; }
 
     /** The ID that was provided to this job when it was initially submitted. */
     private final String _externalId;
@@ -43,7 +43,7 @@ public class JsonCallbackBody {
 
     @JsonCreator
     public JsonCallbackBody(
-            @JsonProperty("jobId") long jobId,
+            @JsonProperty("jobId") String jobId,
             @JsonProperty("externalId") String externalId,
             @JsonProperty("outputObjectUri") String outputObjectUri) {
         _jobId = jobId;

--- a/trunk/interop/src/main/java/org/mitre/mpf/interop/JsonOutputObject.java
+++ b/trunk/interop/src/main/java/org/mitre/mpf/interop/JsonOutputObject.java
@@ -37,8 +37,8 @@ public class JsonOutputObject {
 
     @JsonProperty("jobId")
     @JsonPropertyDescription("The unique identifier assigned to this job by the system.")
-    private long jobId;
-    public long getJobId() { return jobId; }
+    private String jobId;
+    public String getJobId() { return jobId; }
 
     @JsonProperty("priority")
     @JsonPropertyDescription("The relative priority of this job given as a value between 1 and 9 (inclusive).")
@@ -120,7 +120,7 @@ public class JsonOutputObject {
 
 
 
-    public JsonOutputObject(long jobId, String objectId, JsonPipeline pipeline, int priority, String siteId,
+    public JsonOutputObject(String jobId, String objectId, JsonPipeline pipeline, int priority, String siteId,
                             String openmpfVersion, String externalJobId, Instant timeStart, Instant timeStop, String status) {
         this.jobId = jobId;
         this.objectId = objectId;
@@ -142,7 +142,7 @@ public class JsonOutputObject {
 
     @JsonCreator
     public static JsonOutputObject factory(
-            @JsonProperty("jobId") long jobId,
+            @JsonProperty("jobId") String jobId,
             @JsonProperty("objectId") String objectId,
             @JsonProperty("pipeline") JsonPipeline pipeline,
             @JsonProperty("priority") int priority,

--- a/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/JobCreationResponse.java
+++ b/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/JobCreationResponse.java
@@ -27,7 +27,7 @@
 package org.mitre.mpf.rest.api;
 
 public class JobCreationResponse {
-	private long jobId = -1; //will be -1 if there is an error creating the job	
+	private String jobId;  // Will be null if there is an error creating the job
 	private MpfResponse mpfResponse = new MpfResponse();	
 	
 	/*
@@ -37,10 +37,10 @@ public class JobCreationResponse {
 	
 	public JobCreationResponse(int errorCode, String errorMessage) {
 		this.mpfResponse.setMessage(errorCode, errorMessage);
-		this.jobId = -1;
+		this.jobId = null;
 	}
 
-	public JobCreationResponse(long jobId) {
+	public JobCreationResponse(String jobId) {
 		this.mpfResponse.setResponseCode(MpfResponse.RESPONSE_CODE_SUCCESS);
 		this.jobId = jobId;
 	}
@@ -48,7 +48,7 @@ public class JobCreationResponse {
 	/*
 	 * Getters
 	 */
-	public long getJobId() {
+	public String getJobId() {
 		return jobId;
 	}
 	

--- a/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/JobPageModel.java
+++ b/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/JobPageModel.java
@@ -30,6 +30,10 @@ public class JobPageModel extends SingleJobInfo {
 
     private boolean outputFileExists = false;
 
+    private long internalJobId;
+    public long getJobId() { return internalJobId; }
+    public void setJobId(long id) { internalJobId = id; }
+
     public boolean isOutputFileExists() {
         return outputFileExists;
     }
@@ -42,7 +46,7 @@ public class JobPageModel extends SingleJobInfo {
     }
 
     public JobPageModel(SingleJobInfo job) {
-        super(job.getJobId(),
+        super(job.getExportedJobId(),
               job.getPipelineName(),
               job.getJobPriority(),
               job.getJobStatus(),

--- a/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/JobPageModel.java
+++ b/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/JobPageModel.java
@@ -26,13 +26,24 @@
 
 package org.mitre.mpf.rest.api;
 
-public class JobPageModel extends SingleJobInfo {
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+
+public class JobPageModel {
+    private final long jobId;
+    private final String pipelineName;
+    private final int jobPriority;
+    private final String jobStatus;
+    private final float jobProgress;
+    private final Instant startDate;
+    private final Instant endDate;
+    private final String outputObjectPath;
+    private final boolean hasCallbacksInProgress;
+    private final boolean terminal;
+    private final List<String> mediaUris;
 
     private boolean outputFileExists = false;
-
-    private long internalJobId;
-    public long getJobId() { return internalJobId; }
-    public void setJobId(long id) { internalJobId = id; }
 
     public boolean isOutputFileExists() {
         return outputFileExists;
@@ -42,20 +53,72 @@ public class JobPageModel extends SingleJobInfo {
         this.outputFileExists = outputFileExists;
     }
 
-    public JobPageModel() {
+    public JobPageModel(
+            long jobId,
+            String pipelineName,
+            int jobPriority,
+            String jobStatus,
+            float jobProgress,
+            Instant startDate,
+            Instant endDate,
+            String outputObjectPath,
+            boolean hasCallbacksInProgress,
+            boolean terminal,
+            Collection<String> mediaUris) {
+        this.jobId = jobId;
+        this.pipelineName = pipelineName;
+        this.jobPriority = jobPriority;
+        this.jobStatus = jobStatus;
+        this.jobProgress = jobProgress;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.outputObjectPath = outputObjectPath;
+        this.hasCallbacksInProgress = hasCallbacksInProgress;
+        this.terminal = terminal;
+        this.mediaUris = List.copyOf(mediaUris);
     }
 
-    public JobPageModel(SingleJobInfo job) {
-        super(job.getExportedJobId(),
-              job.getPipelineName(),
-              job.getJobPriority(),
-              job.getJobStatus(),
-              job.getJobProgress(),
-              job.getStartDate(),
-              job.getEndDate(),
-              job.getOutputObjectPath(),
-              job.getHasCallbacksInProgress(),
-              job.isTerminal(),
-              job.getMediaUris());
+    public long getJobId() {
+        return jobId;
+    }
+
+    public String getPipelineName() {
+        return pipelineName;
+    }
+
+    public int getJobPriority() {
+        return jobPriority;
+    }
+
+    public String getJobStatus() {
+        return jobStatus;
+    }
+
+    public float getJobProgress() {
+        return jobProgress;
+    }
+
+    public Instant getStartDate() {
+        return startDate;
+    }
+
+    public Instant getEndDate() {
+        return endDate;
+    }
+
+    public String getOutputObjectPath() {
+        return outputObjectPath;
+    }
+
+    public boolean getHasCallbacksInProgress() {
+        return hasCallbacksInProgress;
+    }
+
+    public boolean isTerminal() {
+        return terminal;
+    }
+
+    public List<String> getMediaUris() {
+        return mediaUris;
     }
 }

--- a/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/MarkupResultConvertedModel.java
+++ b/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/MarkupResultConvertedModel.java
@@ -28,7 +28,7 @@ package org.mitre.mpf.rest.api;
 
 public class MarkupResultConvertedModel {
 	private long id;
-	private long jobId;
+	private String jobId;
 	private String pipeline;
 	private String markupUri;
 
@@ -44,7 +44,7 @@ public class MarkupResultConvertedModel {
 	private String sourceDownloadUrl;
 
 	public long getId() { return id; }
-	public long getJobId() { return jobId; }
+	public String getJobId() { return jobId; }
     public String getPipeline() { return pipeline; }
     public String getMarkupUri() { return markupUri; }
     public String getMarkupUriContentType() { return markupUriContentType; }
@@ -63,7 +63,7 @@ public class MarkupResultConvertedModel {
 		this.sourceDownloadUrl = sourceDownloadUrl;
 	}
 
-	public void setJobId(long jobId) {
+	public void setJobId(String jobId) {
 		this.jobId = jobId;
 	}
 
@@ -114,7 +114,7 @@ public class MarkupResultConvertedModel {
 
 	public MarkupResultConvertedModel() {}
 
-    public MarkupResultConvertedModel(long id, long jobId, String pipeline,
+    public MarkupResultConvertedModel(long id, String jobId, String pipeline,
 									  String markupUri, String markupUriContentType,String markupImgUrl,String markupDownloadUrl,boolean markupFileAvailable, String sourceUri,String sourceURIContentType,String sourceImgUrl,String sourceDownloadUrl, boolean sourceFileAvailable) {
 		this.id = id;
 		this.jobId = jobId;

--- a/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/SingleJobInfo.java
+++ b/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/SingleJobInfo.java
@@ -70,7 +70,7 @@ public class SingleJobInfo {
         this.mediaUris = List.copyOf(mediaUris);
     }
 
-    public String getExportedJobId() {
+    public String getJobId() {
         return jobId;
     }
 

--- a/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/SingleJobInfo.java
+++ b/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/SingleJobInfo.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 import java.util.List;
 
 public class SingleJobInfo {
-    private long jobId;
+    private String jobId;
     private String pipelineName;
     private int jobPriority;
     private String jobStatus;
@@ -46,7 +46,7 @@ public class SingleJobInfo {
     public SingleJobInfo() { }
 
     public SingleJobInfo(
-            long jobId,
+            String jobId,
             String pipelineName,
             int jobPriority,
             String jobStatus,
@@ -70,7 +70,7 @@ public class SingleJobInfo {
         this.mediaUris = List.copyOf(mediaUris);
     }
 
-    public long getJobId() {
+    public String getJobId() {
         return jobId;
     }
 

--- a/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/SingleJobInfo.java
+++ b/trunk/mpf-rest-api/src/main/java/org/mitre/mpf/rest/api/SingleJobInfo.java
@@ -70,7 +70,7 @@ public class SingleJobInfo {
         this.mediaUris = List.copyOf(mediaUris);
     }
 
-    public String getJobId() {
+    public String getExportedJobId() {
         return jobId;
     }
 

--- a/trunk/mpf-rest-client/src/main/java/org/mitre/mpf/rest/client/Main.java
+++ b/trunk/mpf-rest-client/src/main/java/org/mitre/mpf/rest/client/Main.java
@@ -177,7 +177,7 @@ public class Main {
 
         // Create a job using the first FACE pipeline
 
-        long jobId = jobCreationResponseEntity.getBody().getJobId();
+        String   jobId = jobCreationResponseEntity.getBody().getJobId();
         System.out.println("Created job with id: " + jobId + "\n");
 
         System.out.println("---Sleeping for 10 seconds to let the job process---\n");

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/JobController.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/JobController.java
@@ -122,7 +122,8 @@ public class JobController {
                     " http://api.example.com/foo?jobid=hostname-1&outputobjecturi=file%3A%2F%2F%2Fpath%2Fto%2F1%2Fdetection.json." +
                     " \n\nThe body of a POST callback will always include the 'jobId', 'externalId', and" +
                     " 'outputObjectUri', even if the latter two are null." +
-                    " \n\nThe job id is a string consisting of the hostname where the job was run plus the numeric job id used internally by OpenMPF." +
+                    " \n\nThe job id that is reported from OPenMPF is a string consisting of the hostname where the job was run plus the" +
+                    " numeric job id used internally by OpenMPF." +
                     " \n\nNote that the batch jobs and streaming jobs share a range of valid job ids. " +
                     " OpenMPF guarantees that the ids of a streaming job and a batch job will be unique." +
                     " \n\nAn optional jobProperties object contains String key-value pairs which override the pipeline's" +

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/JobController.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/JobController.java
@@ -131,10 +131,9 @@ public class JobController {
                     " http://api.example.com/foo?jobid=hostname-1&outputobjecturi=file%3A%2F%2F%2Fpath%2Fto%2F1%2Fdetection.json." +
                     " \n\nThe body of a POST callback will always include the 'jobId', 'externalId', and" +
                     " 'outputObjectUri', even if the latter two are null." +
+                    " \n\nAlso, note that all provided URIs must be properly encoded." +
                     " \n\nThe job id that is reported from OpenMPF is a string consisting of the hostname where the job was run plus the" +
                     " numeric job id used internally by OpenMPF." +
-                    " \n\nNote that the batch jobs and streaming jobs share a range of valid job ids. " +
-                    " OpenMPF guarantees that the ids of a streaming job and a batch job will be unique." +
                     " \n\nAn optional jobProperties object contains String key-value pairs which override the pipeline's" +
                     " job properties for this job." +
                     " \n\nAn optional algorithmProperties object containing <String,Map> key-value pairs can override" +
@@ -145,7 +144,6 @@ public class JobController {
                     "of the video will be processed. Regular segmenting will be applied, except " +
                     "that no gaps between user specified ranges will be filled. The ranges can be " +
                     "specified as frame ranges or time ranges in milliseconds." +
-                    " \nAlso, note that all provided URIs must be properly encoded." +
                     " \n\nWithin media, an optional metadata object containing String key-value pairs can override" +
                     " media inspection once the required metadata information is provided for audio, image, generic, and video jobs." +
                     " \nFor media metadata, note that optional parameters like `ROTATION` and `HORIZONTAL_FLIP` can also be provided.",

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/JobController.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/JobController.java
@@ -231,6 +231,7 @@ public class JobController {
         for (int i = 0; i < jobInfoModels.size(); i++) {
             SingleJobInfo job = jobInfoModels.get(i);
             JobPageModel job_model = new JobPageModel(job);
+            job_model.setJobId(propertiesUtil.getJobIdFromExportedId(job.getExportedJobId()));
             if(job_model.getOutputObjectPath() != null) {
                 job_model.setOutputFileExists(
                         IoUtils.toLocalPath(job_model.getOutputObjectPath())

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/ServerMediaController.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/mvc/controller/ServerMediaController.java
@@ -207,14 +207,14 @@ public class ServerMediaController {
     @RequestMapping(value = "/server/download", method = RequestMethod.GET)
     @ResponseBody
     public void download(HttpServletResponse response,
-                         @RequestParam("jobId") long jobId,
+                         @RequestParam("jobId") String jobId,
                          @RequestParam("sourceUri") URI sourceUri) throws IOException, StorageException {
 
         if ("file".equalsIgnoreCase(sourceUri.getScheme())) {
             ioUtils.sendBinaryResponse(Paths.get(sourceUri), response);
         }
-
-        JobRequest jobRequest = jobRequestDao.findById(jobId);
+        long internalJobId = propertiesUtil.getJobIdFromExportedId(jobId);
+        JobRequest jobRequest = jobRequestDao.findById(internalJobId);
         if (jobRequest == null) {
             response.setStatus(404);
             response.flushBuffer();

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/JobCompleteProcessorImpl.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/JobCompleteProcessorImpl.java
@@ -260,7 +260,7 @@ public class JobCompleteProcessorImpl extends WfmProcessor implements JobComplet
                 .setConnectTimeout(propertiesUtil.getHttpCallbackTimeoutMs())
                 .build();
 
-        String exportedJobId = propertiesUtil.getHostName() + job.getId();
+        String exportedJobId = propertiesUtil.getHostName() + "-" + job.getId();
 
         if ("GET".equals(jsonCallbackMethod)) {
             URIBuilder callbackUriWithParamsBuilder = new URIBuilder(jsonCallbackURL)

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/JobCompleteProcessorImpl.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/JobCompleteProcessorImpl.java
@@ -283,8 +283,9 @@ public class JobCompleteProcessorImpl extends WfmProcessor implements JobComplet
                 ? null
                 : outputObjectUri.toString();
 
+        String exportedJobId = propertiesUtil.getHostName() + "-" + job.getId();
         JsonCallbackBody jsonBody = new JsonCallbackBody(
-                job.getId(), job.getExternalId().orElse(null), outputObjectUriString);
+                exportedJobId, job.getExternalId().orElse(null), outputObjectUriString);
 
         postRequest.setEntity(new StringEntity(jsonUtils.serializeAsTextString(jsonBody),
                                                ContentType.APPLICATION_JSON));
@@ -319,9 +320,9 @@ public class JobCompleteProcessorImpl extends WfmProcessor implements JobComplet
                                   Mutable<String> outputSha,
                                   TrackCounter trackCounter) throws IOException {
         long jobId = job.getId();
-
+        String exportedJobId = propertiesUtil.getHostName() + "-" + job.getId();
         JsonOutputObject jsonOutputObject = new JsonOutputObject(
-                jobId,
+                exportedJobId,
                 UUID.randomUUID().toString(),
                 convertPipeline(job.getPipelineElements()),
                 job.getPriority(),

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/JobCompleteProcessorImpl.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/JobCompleteProcessorImpl.java
@@ -260,9 +260,11 @@ public class JobCompleteProcessorImpl extends WfmProcessor implements JobComplet
                 .setConnectTimeout(propertiesUtil.getHttpCallbackTimeoutMs())
                 .build();
 
+        String exportedJobId = propertiesUtil.getHostName() + job.getId();
+
         if ("GET".equals(jsonCallbackMethod)) {
             URIBuilder callbackUriWithParamsBuilder = new URIBuilder(jsonCallbackURL)
-                    .setParameter("jobid", String.valueOf(job.getId()));
+                    .setParameter("jobid", exportedJobId);
 
             job.getExternalId()
                     .ifPresent(id -> callbackUriWithParamsBuilder.setParameter("externalid", id));
@@ -283,7 +285,6 @@ public class JobCompleteProcessorImpl extends WfmProcessor implements JobComplet
                 ? null
                 : outputObjectUri.toString();
 
-        String exportedJobId = propertiesUtil.getHostName() + "-" + job.getId();
         JsonCallbackBody jsonBody = new JsonCallbackBody(
                 exportedJobId, job.getExternalId().orElse(null), outputObjectUriString);
 

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/CustomNginxStorageBackend.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/CustomNginxStorageBackend.java
@@ -110,7 +110,8 @@ public class CustomNginxStorageBackend implements StorageBackend {
 
     @Override
     public boolean canStore(JsonOutputObject outputObject) throws StorageException {
-        return canStore(outputObject.getJobId());
+        long internalJobId = _propertiesUtil.getJobIdFromExportedId(outputObject.getJobId());
+        return canStore(internalJobId);
     }
 
     private boolean canStore(long jobId) throws StorageException {
@@ -122,7 +123,8 @@ public class CustomNginxStorageBackend implements StorageBackend {
 
     @Override
     public URI store(JsonOutputObject outputObject, Mutable<String> outputSha) throws StorageException, IOException {
-        URI serviceUri = getServiceUri(outputObject.getJobId());
+        long internalJobId = _propertiesUtil.getJobIdFromExportedId(outputObject.getJobId());
+        URI serviceUri = getServiceUri(internalJobId);
         if (outputSha.getValue() == null) {
             MessageDigest digest = DigestUtils.getSha256Digest();
             URI result;

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/LocalStorageBackend.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/LocalStorageBackend.java
@@ -72,7 +72,8 @@ public class LocalStorageBackend implements StorageBackend {
 
     @Override
     public URI store(JsonOutputObject outputObject, Mutable<String> outputSha) throws IOException {
-        Path outputPath = _propertiesUtil.createDetectionOutputObjectFile(outputObject.getJobId());
+        long internalJobId = _propertiesUtil.getJobIdFromExportedId(outputObject.getJobId());
+        Path outputPath = _propertiesUtil.createDetectionOutputObjectFile(internalJobId);
         if (outputSha.getValue() == null) {
             MessageDigest digest = DigestUtils.getSha256Digest();
             try (var outStream = new DigestOutputStream(Files.newOutputStream(outputPath), digest)) {

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/S3StorageBackend.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/S3StorageBackend.java
@@ -100,14 +100,16 @@ public class S3StorageBackend implements StorageBackend {
 
     @Override
     public boolean canStore(JsonOutputObject outputObject) throws StorageException {
-        BatchJob job = _inProgressJobs.getJob(outputObject.getJobId());
+        long internalJobId = _propertiesUtil.getJobIdFromExportedId(outputObject.getJobId());
+        BatchJob job = _inProgressJobs.getJob(internalJobId);
         return requiresS3ResultUpload(job.getJobProperties()::get);
     }
 
     @Override
     public URI store(JsonOutputObject outputObject, Mutable<String> outputSha) throws StorageException, IOException {
         URI localUri = _localStorageBackend.store(outputObject, outputSha);
-        BatchJob job = _inProgressJobs.getJob(outputObject.getJobId());
+        long internalJobId = _propertiesUtil.getJobIdFromExportedId(outputObject.getJobId());
+        BatchJob job = _inProgressJobs.getJob(internalJobId);
         if (outputSha.getValue() == null) {
             outputSha.setValue(hashExistingFile(Paths.get(localUri)));
         }

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/TiesDbService.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/TiesDbService.java
@@ -194,7 +194,7 @@ public class TiesDbService {
                 Map.entry("processDate", timeCompleted),
                 Map.entry("jobStatus", jobStatus),
                 Map.entry("systemVersion", _propertiesUtil.getSemanticVersion()),
-                Map.entry("systemHostname", getHostName()),
+                Map.entry("systemHostname", _propertiesUtil.getHostName()),
                 Map.entry("trackCount", trackCount)
         );
 
@@ -228,13 +228,6 @@ public class TiesDbService {
         digest.update(algorithm.getBytes(StandardCharsets.UTF_8));
         digest.update(String.valueOf(endTime.getEpochSecond()).getBytes(StandardCharsets.UTF_8));
         return Hex.encodeHexString(digest.digest());
-    }
-
-
-    private static String getHostName() {
-        return Objects.requireNonNullElseGet(
-                System.getenv("NODE_HOSTNAME"),
-                () -> System.getenv("HOSTNAME"));
     }
 
 

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/TiesDbService.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/service/TiesDbService.java
@@ -188,7 +188,7 @@ public class TiesDbService {
                 Map.entry("pipeline", jobPart.getPipeline().getName()),
                 Map.entry("algorithm", algoName),
                 Map.entry("outputType", trackType),
-                Map.entry("jobId", jobPart.getJob().getId()),
+                Map.entry("jobId", _propertiesUtil.getExportedJobId(jobPart.getJob().getId())),
                 Map.entry("outputUri", outputObjectLocation.toString()),
                 Map.entry("sha256OutputHash", outputObjectSha),
                 Map.entry("processDate", timeCompleted),
@@ -199,7 +199,7 @@ public class TiesDbService {
         );
 
         var assertionId = getAssertionId(
-                jobPart.getJob().getId(),
+                _propertiesUtil.getExportedJobId(jobPart.getJob().getId()),
                 trackType,
                 jobPart.getAlgorithm().getName(), timeCompleted);
 
@@ -220,10 +220,10 @@ public class TiesDbService {
     }
 
 
-    private static String getAssertionId(long jobId, String detectionType, String algorithm,
+    private static String getAssertionId(String jobId, String detectionType, String algorithm,
                                          Instant endTime) {
         var digest = DigestUtils.getSha256Digest();
-        digest.update(String.valueOf(jobId).getBytes(StandardCharsets.UTF_8));
+        digest.update(jobId.getBytes(StandardCharsets.UTF_8));
         digest.update(detectionType.getBytes(StandardCharsets.UTF_8));
         digest.update(algorithm.getBytes(StandardCharsets.UTF_8));
         digest.update(String.valueOf(endTime.getEpochSecond()).getBytes(StandardCharsets.UTF_8));

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/InvalidJobIdException.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/InvalidJobIdException.java
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * NOTICE                                                                     *
+ *                                                                            *
+ * This software (or technical data) was produced for the U.S. Government     *
+ * under contract, and is subject to the Rights in Data-General Clause        *
+ * 52.227-14, Alt. IV (DEC 2007).                                             *
+ *                                                                            *
+ * Copyright 2021 The MITRE Corporation. All Rights Reserved.                 *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Copyright 2021 The MITRE Corporation                                       *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License");            *
+ * you may not use this file except in compliance with the License.           *
+ * You may obtain a copy of the License at                                    *
+ *                                                                            *
+ *    http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ ******************************************************************************/
+
+
+package org.mitre.mpf.wfm.util;
+
+import org.mitre.mpf.wfm.WfmProcessingException;
+
+public class InvalidJobIdException extends WfmProcessingException {
+
+    public InvalidJobIdException(String message) {
+        super(message);
+    }
+
+    public InvalidJobIdException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
@@ -263,6 +263,14 @@ public class PropertiesUtil {
         return mpfPropertiesConfig.getString("output.site.name");
     }
 
+    public String getHostName() {
+        return Objects.requireNonNullElseGet(
+                System.getenv("NODE_HOSTNAME"),
+                () -> System.getenv("HOSTNAME"));
+    }
+
+
+
     public boolean isStreamingOutputObjectsToDiskEnabled() {
         return mpfPropertiesConfig.getBoolean("mpf.streaming.output.objects.to.disk.enabled");
     }

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
@@ -269,7 +269,10 @@ public class PropertiesUtil {
                 () -> System.getenv("HOSTNAME"));
     }
 
-
+    public long getJobIdFromExportedId(String exportedId) {
+        String[] tokens = exportedId.split("-");
+        return Long.parseLong(tokens[tokens.length-1]);
+    }
 
     public boolean isStreamingOutputObjectsToDiskEnabled() {
         return mpfPropertiesConfig.getBoolean("mpf.streaming.output.objects.to.disk.enabled");

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
@@ -271,7 +271,18 @@ public class PropertiesUtil {
 
     public long getJobIdFromExportedId(String exportedId) {
         String[] tokens = exportedId.split("-");
-        return Long.parseLong(tokens[tokens.length-1]);
+        try {
+            return Long.parseLong(tokens[tokens.length - 1]);
+        }
+        catch (NumberFormatException e) {
+            throw new InvalidJobIdException(
+                    "Failed to parse job id of \"" + exportedId +
+                            "\". Expected a job id like <hostname>-<integer>.", e);
+        }
+    }
+
+    public String getExportedJobId(long jobId) {
+        return getHostName() + "-" + jobId;
     }
 
     public boolean isStreamingOutputObjectsToDiskEnabled() {

--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/util/PropertiesUtil.java
@@ -276,8 +276,8 @@ public class PropertiesUtil {
         }
         catch (NumberFormatException e) {
             throw new InvalidJobIdException(
-                    "Failed to parse job id of \"" + exportedId +
-                            "\". Expected a job id like <hostname>-<integer>.", e);
+                    "Failed to parse job id of '" + exportedId +
+                            "'. Expected a job id like <hostname>-<integer>.", e);
         }
     }
 

--- a/trunk/workflow-manager/src/main/webapp/resources/mytheme/js/controllers/ServerMediaCtrl.js
+++ b/trunk/workflow-manager/src/main/webapp/resources/mytheme/js/controllers/ServerMediaCtrl.js
@@ -736,7 +736,9 @@
                     //finally submit the job
                     MediaService.createJobFromMedia(jobCreationRequest).then(function (jobCreationResponse) {
                         if (jobCreationResponse.mpfResponse.responseCode == 0) {
-                            NotificationSvc.success('Job ' + jobCreationResponse.jobId + ' created!');
+                            const idTokens = jobCreationResponse.jobId.split("-");
+                            var internalJobId = idTokens[idTokens.length-1];
+                            NotificationSvc.success('Job ' + internalJobId + ' created!');
                             $log.info('successful job creation - switch to jobs view');
 
                             $location.path('/jobs');//go to jobs view

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
@@ -1023,6 +1023,7 @@ public class ITWebREST {
 			// attempts have been made.
 			// GET and POST both use the same code to handle callback failures.
 			JsonCallbackBody getCallbackContent = getCallbackResult.get();
+			log.info("jobId = " + jobId + " callback job id = " +getCallbackContent.getJobId());
 			Assert.assertEquals(jobId, getCallbackContent.getJobId());
 			Assert.assertEquals(externalId, getCallbackContent.getExternalId());
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
@@ -1023,7 +1023,7 @@ public class ITWebREST {
 			// attempts have been made.
 			// GET and POST both use the same code to handle callback failures.
 			JsonCallbackBody getCallbackContent = getCallbackResult.get();
-			log.info("jobId = " + jobId + " callback job id = " +getCallbackContent.getJobId());
+			log.info("jobId = " + jobId + " callback job id = " + getCallbackContent.getJobId());
 			Assert.assertEquals(jobId, getCallbackContent.getJobId());
 			Assert.assertEquals(externalId, getCallbackContent.getExternalId());
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
@@ -993,7 +993,7 @@ public class ITWebREST {
 			String postResponseJson = WebRESTUtils.postJSON(new URL(url), param_string, WebRESTUtils.MPF_AUTHORIZATION);
 			log.info("results:" + postResponseJson);// {"errorCode":0,"errorMessage":null,"jobId":5}
 			JSONObject obj = new JSONObject(postResponseJson);
-			long jobId = obj.getLong("jobId");
+			String jobId = obj.getString("jobId");
 
 			//wait for it to callback
 			log.info("Waiting for POST callback...");
@@ -1012,7 +1012,7 @@ public class ITWebREST {
 			postResponseJson = WebRESTUtils.postJSON(new URL(url), param_string, WebRESTUtils.MPF_AUTHORIZATION);
 			log.info("results:" + postResponseJson);// {"errorCode":0,"errorMessage":null,"jobId":5}
 			obj = new JSONObject(postResponseJson);
-			jobId =  obj.getLong("jobId");
+			jobId =  obj.getString("jobId");
 
 			//wait for it to callback
 			log.info("Waiting for GET callback...");
@@ -1053,7 +1053,7 @@ public class ITWebREST {
 
 		Spark.get("/callback", (request, resp) -> {
 			try {
-			    long jobId = Long.parseLong(request.queryParams("jobid"));
+			    String jobId = request.queryParams("jobid");
 				log.info("Spark received GET callback with url: " + request.url() + '?' + request.queryString());
 
 				JsonCallbackBody callbackBody = new JsonCallbackBody(

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
@@ -1028,8 +1028,10 @@ public class ITWebREST {
 			Assert.assertEquals(externalId, getCallbackContent.getExternalId());
 
 			Assert.assertTrue(getCallbackContent.getOutputObjectUri().startsWith("file:///"));
+			tokens = jobId.split("-");
+			internalJobId = Long.parseLong(tokens[tokens.length-1]);
 			Assert.assertTrue(getCallbackContent.getOutputObjectUri().endsWith(
-					String.format("output-objects/%s/detection.json", jobId)));
+					String.format("output-objects/%s/detection.json", internalJobId)));
 
 			var jobResponseObj = new JSONObject(WebRESTUtils.getJSON(new URL(url + '/' + jobId),
 			                                                         WebRESTUtils.MPF_AUTHORIZATION));

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/ITWebREST.java
@@ -442,7 +442,7 @@ public class ITWebREST {
 		log.info("[test_Jobs_SerializedOutput] - {} - json: {}", outputObjectType,
 				json.toString());
 		if(outputObjectType.equals("detection")) {
-			Assert.assertSame(json.get("jobId"), completeJobId);
+			Assert.assertTrue(Objects.equals(json.get("jobId"), completeJobId));
 			Assert.assertTrue(((String) json.get("objectId")).length() > 0);
 			Assert.assertTrue(((String) json.get("timeStart")).length() > 0);
 			org.json.simple.JSONObject pipeline = (org.json.simple.JSONObject) json.get("pipeline");
@@ -1002,8 +1002,10 @@ public class ITWebREST {
 			Assert.assertEquals(externalId, postCallbackContent.getExternalId());
 
 			Assert.assertTrue(postCallbackContent.getOutputObjectUri().startsWith("file:///"));
+			String[] tokens = jobId.split("-");
+			long internalJobId = Long.parseLong(tokens[tokens.length-1]);
 			Assert.assertTrue(postCallbackContent.getOutputObjectUri().endsWith(
-					String.format("output-objects/%s/detection.json", jobId)));
+					String.format("output-objects/%s/detection.json", internalJobId)));
 
 			//test GET
 			params.put("callbackMethod","GET");

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/WebRESTUtils.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/WebRESTUtils.java
@@ -214,20 +214,20 @@ public class WebRESTUtils {
 		return sb.toString();
 	}
 
-	public static SingleJobInfo getSingleJobInfo(long jobId) throws JsonParseException, JsonMappingException, IOException {
-		String urlJobsStatus = REST_URL + "jobs/" + Long.toString(jobId) + ".json";
+	public static SingleJobInfo getSingleJobInfo(String jobId) throws JsonParseException, JsonMappingException, IOException {
+		String urlJobsStatus = REST_URL + "jobs/" + jobId + ".json";
 		String jsonJobResponse = getJSON(new URL(urlJobsStatus), MPF_AUTHORIZATION);
-		Assert.assertTrue("Failed to retrieve JSON when GETting job info for job id: " + Long.toString(jobId), jsonJobResponse.length() >= 0);
+		Assert.assertTrue("Failed to retrieve JSON when GETting job info for job id: " + jobId, jsonJobResponse.length() >= 0);
 		return objectMapper.readValue(jsonJobResponse, SingleJobInfo.class);
 	}
 
-	public static BatchJobStatusType getJobsStatus(long jobid)throws JsonParseException, JsonMappingException, IOException  {
+	public static BatchJobStatusType getJobsStatus(String jobid)throws JsonParseException, JsonMappingException, IOException  {
 		SingleJobInfo singleJobInfo = getSingleJobInfo(jobid);
 		//convert to the enum and return
 		return BatchJobStatusType.valueOf(singleJobInfo.getJobStatus());
 	}
 
-	public static boolean waitForJobToTerminate(long jobid, long delay) throws InterruptedException, JsonParseException, JsonMappingException, IOException {
+	public static boolean waitForJobToTerminate(String jobid, long delay) throws InterruptedException, JsonParseException, JsonMappingException, IOException {
 		log.info("[waitForJobToTerminate] job {}, delay:{} ", jobid, delay);
 		int count=20;
 		BatchJobStatusType status;

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestCustomNginxStorageBackend.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestCustomNginxStorageBackend.java
@@ -125,6 +125,9 @@ public class TestCustomNginxStorageBackend {
         when(_mockPropertiesUtil.getHttpStorageUploadRetryCount())
                 .thenReturn(2);
 
+        when(_mockPropertiesUtil.getJobIdFromExportedId(TEST_JOB_ID))
+                .thenReturn(TEST_INTERNAL_JOB_ID);
+
         setStorageUri(SERVICE_URI.toString());
 
         BAD_PATH_POST_COUNT.set(0);

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestCustomNginxStorageBackend.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestCustomNginxStorageBackend.java
@@ -79,7 +79,8 @@ import static org.mockito.Mockito.when;
 
 public class TestCustomNginxStorageBackend {
 
-    private static final long TEST_JOB_ID = 62343245;
+    private static final String TEST_JOB_ID = "localhost-555";
+    private static final long TEST_INTERNAL_JOB_ID = 555;
 
     private static final String TEST_FILE = "/samples/video_01.mp4";
 
@@ -139,13 +140,13 @@ public class TestCustomNginxStorageBackend {
         when(job.getSystemPropertiesSnapshot())
                 .thenReturn(propertiesSnapshot);
 
-        when(_mockInProgressJobs.getJob(TEST_JOB_ID))
+        when(_mockInProgressJobs.getJob(TEST_INTERNAL_JOB_ID))
                 .thenReturn(job);
     }
 
     private MarkupResult createMarkupResult() throws IOException {
         MarkupResult markup = new MarkupResult();
-        markup.setJobId(TEST_JOB_ID);
+        markup.setJobId(TEST_INTERNAL_JOB_ID);
         markup.setMarkupUri(getTestFileCopy().toUri().toString());
         return markup;
     }
@@ -292,7 +293,7 @@ public class TestCustomNginxStorageBackend {
         }
 
         ArtifactExtractionRequest request = new ArtifactExtractionRequest(
-                TEST_JOB_ID,
+                TEST_INTERNAL_JOB_ID,
                 0,
                 testFile.toString(),
                 MediaType.VIDEO,

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestS3StorageBackend.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestS3StorageBackend.java
@@ -255,9 +255,10 @@ public class TestS3StorageBackend {
 
     private JsonOutputObject setJobProperties(Map<String, String> properties) {
         long jobId = 123;
+        String exportedJobId = "localhost-123";
         JsonOutputObject outputObject = mock(JsonOutputObject.class);
         when(outputObject.getJobId())
-                .thenReturn(jobId);
+                .thenReturn(exportedJobId);
 
         var mockJob = mock(BatchJob.class);
         when(mockJob.getJobProperties())

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestS3StorageBackend.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestS3StorageBackend.java
@@ -256,6 +256,9 @@ public class TestS3StorageBackend {
     private JsonOutputObject setJobProperties(Map<String, String> properties) {
         long jobId = 123;
         String exportedJobId = "localhost-123";
+        when(_mockPropertiesUtil.getJobIdFromExportedId(exportedJobId))
+                .thenReturn(jobId);
+
         JsonOutputObject outputObject = mock(JsonOutputObject.class);
         when(outputObject.getJobId())
                 .thenReturn(exportedJobId);

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestStorageService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestStorageService.java
@@ -138,9 +138,10 @@ public class TestStorageService {
     @Test
     public void outputObjectGetsStoredLocallyWhenBackendException() throws IOException, StorageException {
         long jobId = 867;
+        String exportedJobId = "localhost-867";
         JsonOutputObject outputObject = mock(JsonOutputObject.class);
         when(outputObject.getJobId())
-                .thenReturn(jobId);
+                .thenReturn(exportedJobId);
         SortedSet<JsonMediaIssue> warnings = setupWarnings(outputObject);
         setInitialJobStatus(jobId, BatchJobStatusType.COMPLETE);
 
@@ -163,9 +164,10 @@ public class TestStorageService {
     @Test
     public void outputObjectGetsStoredLocallyWhenCanStoreFails() throws StorageException, IOException {
         long jobId = 869;
+        String exportedJobId = "localhost-869";
         JsonOutputObject outputObject = mock(JsonOutputObject.class);
         when(outputObject.getJobId())
-                .thenReturn(jobId);
+                .thenReturn(exportedJobId);
 
         SortedSet<JsonMediaIssue> warnings = setupWarnings(outputObject);
         setInitialJobStatus(jobId, BatchJobStatusType.COMPLETE);
@@ -190,9 +192,10 @@ public class TestStorageService {
     @Test
     public void throwsExceptionWhenFailsToStoreLocally() throws IOException, StorageException {
         long jobId = 598;
+        String exportedJobId = "localhost-598";
         JsonOutputObject outputObject = mock(JsonOutputObject.class);
         when(outputObject.getJobId())
-                .thenReturn(jobId);
+                .thenReturn(exportedJobId);
         SortedSet<JsonMediaIssue> warnings = setupWarnings(outputObject);
         setInitialJobStatus(jobId, BatchJobStatusType.COMPLETE);
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestStorageService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestStorageService.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.mitre.mpf.interop.JsonDetectionOutputObject;
 import org.mitre.mpf.interop.JsonIssueDetails;
 import org.mitre.mpf.interop.JsonMediaIssue;
 import org.mitre.mpf.interop.JsonOutputObject;
@@ -41,6 +42,7 @@ import org.mitre.mpf.wfm.data.InProgressBatchJobsService;
 import org.mitre.mpf.wfm.data.entities.persistent.BatchJob;
 import org.mitre.mpf.wfm.data.entities.persistent.MarkupResult;
 import org.mitre.mpf.wfm.enums.*;
+import org.mitre.mpf.wfm.util.PropertiesUtil;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -73,30 +75,43 @@ public class TestStorageService {
     @Mock
     private LocalStorageBackend _mockLocalBackend;
 
+    @Mock
+    private PropertiesUtil _mockPropertiesUtil;
+
+    private final JsonOutputObject _mockOutputObject = mock(JsonOutputObject.class);
+
     private static final URI TEST_REMOTE_URI = URI.create("http://somehost.xyz/path");
 
     private static final URI TEST_LOCAL_URI = URI.create("file:///path");
 
+    private static final long TEST_INTERNAL_JOB_ID = 2;
+    private static final String TEST_EXPORTED_JOB_ID = "localhost-2";
+
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
+        when(_mockPropertiesUtil.getHostName())
+                .thenReturn("localhost");
+        when(_mockPropertiesUtil.getJobIdFromExportedId(TEST_EXPORTED_JOB_ID))
+                .thenReturn(TEST_INTERNAL_JOB_ID);
+        when(_mockOutputObject.getJobId())
+                .thenReturn(TEST_EXPORTED_JOB_ID);
     }
 
 
     @Test
     public void S3BackendHasHigherPriorityThanNginx() throws IOException, StorageException {
-        JsonOutputObject outputObject = mock(JsonOutputObject.class);
-        when(_mockS3Backend.canStore(outputObject))
+        when(_mockS3Backend.canStore(_mockOutputObject))
                 .thenReturn(true);
-        when(_mockNginxBackend.canStore(outputObject))
+        when(_mockNginxBackend.canStore(_mockOutputObject))
                 .thenReturn(true);
 
         var outputSha = new MutableObject<String>();
-        _storageService.store(outputObject, outputSha);
+        _storageService.store(_mockOutputObject, outputSha);
 
         verifyNoInProgressJobWarnings();
         verify(_mockS3Backend)
-                .store(outputObject, outputSha);
+                .store(_mockOutputObject, outputSha);
         verify(_mockNginxBackend, never())
                 .store(any(JsonOutputObject.class), any());
     }
@@ -104,15 +119,14 @@ public class TestStorageService {
 
     @Test
     public void canStoreOutputObjectRemotely() throws IOException, StorageException {
-        JsonOutputObject outputObject = mock(JsonOutputObject.class);
 
-        when(_mockS3Backend.canStore(outputObject))
+        when(_mockS3Backend.canStore(_mockOutputObject))
                 .thenReturn(true);
 
-        when(_mockS3Backend.store(same(outputObject), any()))
+        when(_mockS3Backend.store(same(_mockOutputObject), any()))
                 .thenReturn(TEST_REMOTE_URI);
 
-        URI result = _storageService.store(outputObject, new MutableObject<>());
+        URI result = _storageService.store(_mockOutputObject, new MutableObject<>());
         assertEquals(TEST_REMOTE_URI, result);
 
         verifyZeroInteractions(_mockLocalBackend);
@@ -121,67 +135,57 @@ public class TestStorageService {
 
     @Test
     public void canStoreOutputObjectLocally() throws IOException, StorageException {
-        JsonOutputObject outputObject = mock(JsonOutputObject.class);
-        when(_mockLocalBackend.store(same(outputObject), any()))
+        when(_mockLocalBackend.store(same(_mockOutputObject), any()))
                 .thenReturn(TEST_LOCAL_URI);
 
-        URI result = _storageService.store(outputObject, new MutableObject<>());
+        URI result = _storageService.store(_mockOutputObject, new MutableObject<>());
         assertEquals(TEST_LOCAL_URI, result);
 
         verifyNoInProgressJobWarnings();
         verify(_mockS3Backend)
-                .canStore(outputObject);
+                .canStore(_mockOutputObject);
         verify(_mockNginxBackend)
-                .canStore(outputObject);
+                .canStore(_mockOutputObject);
     }
 
     @Test
     public void outputObjectGetsStoredLocallyWhenBackendException() throws IOException, StorageException {
-        long jobId = 867;
-        String exportedJobId = "localhost-867";
-        JsonOutputObject outputObject = mock(JsonOutputObject.class);
-        when(outputObject.getJobId())
-                .thenReturn(exportedJobId);
-        SortedSet<JsonMediaIssue> warnings = setupWarnings(outputObject);
-        setInitialJobStatus(jobId, BatchJobStatusType.COMPLETE);
+        SortedSet<JsonMediaIssue> warnings = setupWarnings(_mockOutputObject);
+        setInitialJobStatus(TEST_INTERNAL_JOB_ID, BatchJobStatusType.COMPLETE);
 
-        when(_mockS3Backend.canStore(outputObject))
+
+        when(_mockS3Backend.canStore(_mockOutputObject))
                 .thenReturn(true);
         doThrow(StorageException.class)
-                .when(_mockS3Backend).store(same(outputObject), any());
+                .when(_mockS3Backend).store(same(_mockOutputObject), any());
 
-        when(_mockLocalBackend.store(same(outputObject), any()))
+        when(_mockLocalBackend.store(same(_mockOutputObject), any()))
                 .thenReturn(TEST_LOCAL_URI);
 
-        URI result = _storageService.store(outputObject, new MutableObject<>());
+        URI result = _storageService.store(_mockOutputObject, new MutableObject<>());
         assertEquals(TEST_LOCAL_URI, result);
 
-        verifyJobWarning(jobId);
+        verifyJobWarning(TEST_INTERNAL_JOB_ID);
         verifySingleWarningAddedToOutputObject(0, warnings);
     }
 
 
     @Test
     public void outputObjectGetsStoredLocallyWhenCanStoreFails() throws StorageException, IOException {
-        long jobId = 869;
-        String exportedJobId = "localhost-869";
-        JsonOutputObject outputObject = mock(JsonOutputObject.class);
-        when(outputObject.getJobId())
-                .thenReturn(exportedJobId);
 
-        SortedSet<JsonMediaIssue> warnings = setupWarnings(outputObject);
-        setInitialJobStatus(jobId, BatchJobStatusType.COMPLETE);
+        SortedSet<JsonMediaIssue> warnings = setupWarnings(_mockOutputObject);
+        setInitialJobStatus(TEST_INTERNAL_JOB_ID, BatchJobStatusType.COMPLETE);
 
         doThrow(StorageException.class)
-                .when(_mockNginxBackend).canStore(outputObject);
+                .when(_mockNginxBackend).canStore(_mockOutputObject);
 
-        when(_mockLocalBackend.store(same(outputObject), any()))
+        when(_mockLocalBackend.store(same(_mockOutputObject), any()))
                 .thenReturn(TEST_LOCAL_URI);
 
-        URI result = _storageService.store(outputObject, new MutableObject<>());
+        URI result = _storageService.store(_mockOutputObject, new MutableObject<>());
         assertEquals(TEST_LOCAL_URI, result);
 
-        verifyJobWarning(jobId);
+        verifyJobWarning(TEST_INTERNAL_JOB_ID);
         verifySingleWarningAddedToOutputObject(0, warnings);
 
         verify(_mockNginxBackend, never())
@@ -191,25 +195,20 @@ public class TestStorageService {
 
     @Test
     public void throwsExceptionWhenFailsToStoreLocally() throws IOException, StorageException {
-        long jobId = 598;
-        String exportedJobId = "localhost-598";
-        JsonOutputObject outputObject = mock(JsonOutputObject.class);
-        when(outputObject.getJobId())
-                .thenReturn(exportedJobId);
-        SortedSet<JsonMediaIssue> warnings = setupWarnings(outputObject);
-        setInitialJobStatus(jobId, BatchJobStatusType.COMPLETE);
+        SortedSet<JsonMediaIssue> warnings = setupWarnings(_mockOutputObject);
+        setInitialJobStatus(TEST_INTERNAL_JOB_ID, BatchJobStatusType.COMPLETE);
 
-        when(_mockS3Backend.canStore(outputObject))
+        when(_mockS3Backend.canStore(_mockOutputObject))
                 .thenReturn(true);
 
         doThrow(StorageException.class)
-                .when(_mockS3Backend).store(same(outputObject), any());
+                .when(_mockS3Backend).store(same(_mockOutputObject), any());
 
         doThrow(new IOException("test"))
-                .when(_mockLocalBackend).store(same(outputObject), any());
+                .when(_mockLocalBackend).store(same(_mockOutputObject), any());
 
         try {
-            _storageService.store(outputObject, new MutableObject<>());
+            _storageService.store(_mockOutputObject, new MutableObject<>());
             fail("Expected IOException");
         }
         catch (IOException e) {

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestTiesDbService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestTiesDbService.java
@@ -102,6 +102,10 @@ public class TestTiesDbService {
 
         when(_mockPropertiesUtil.getHostName())
                 .thenReturn("localhost");
+
+        when(_mockPropertiesUtil.getExportedJobId(anyLong()))
+                .thenReturn("localhost-123");
+
     }
 
 
@@ -182,7 +186,7 @@ public class TestTiesDbService {
         verify(_mockCallbackUtils)
                 .executeRequest(
                         argThat(req -> httpRequestMatcher(
-                                job.getId(),
+                                _mockPropertiesUtil.getExportedJobId(job.getId()),
                                 BatchJobStatusType.COMPLETE_WITH_WARNINGS,
                                 media1,
                                 url1,
@@ -198,7 +202,7 @@ public class TestTiesDbService {
         verify(_mockCallbackUtils)
                 .executeRequest(
                         argThat(req -> httpRequestMatcher(
-                                job.getId(),
+                                _mockPropertiesUtil.getExportedJobId(job.getId()),
                                 BatchJobStatusType.COMPLETE_WITH_WARNINGS,
                                 media1,
                                 url2,
@@ -214,7 +218,7 @@ public class TestTiesDbService {
         verify(_mockCallbackUtils)
                 .executeRequest(
                         argThat(req -> httpRequestMatcher(
-                                job.getId(),
+                                _mockPropertiesUtil.getExportedJobId(job.getId()),
                                 BatchJobStatusType.COMPLETE_WITH_WARNINGS,
                                 media2,
                                 url1,
@@ -285,7 +289,7 @@ public class TestTiesDbService {
         verify(_mockCallbackUtils)
                 .executeRequest(
                         argThat(req -> httpRequestMatcher(
-                                job.getId(),
+                                _mockPropertiesUtil.getExportedJobId(job.getId()),
                                 BatchJobStatusType.COMPLETE_WITH_WARNINGS,
                                 job.getMedia().iterator().next(),
                                 url,
@@ -352,7 +356,7 @@ public class TestTiesDbService {
             verify(_mockCallbackUtils)
                     .executeRequest(
                             argThat(req -> httpRequestMatcher(
-                                    job.getId(),
+                                    _mockPropertiesUtil.getExportedJobId(job.getId()),
                                     BatchJobStatusType.COMPLETE,
                                     job.getMedia().iterator().next(),
                                     url,
@@ -369,7 +373,7 @@ public class TestTiesDbService {
         verify(_mockCallbackUtils)
                 .executeRequest(
                         argThat(req -> httpRequestMatcher(
-                                job.getId(),
+                                _mockPropertiesUtil.getExportedJobId(job.getId()),
                                 BatchJobStatusType.COMPLETE,
                                 job.getMedia().iterator().next(),
                                 url,
@@ -437,7 +441,7 @@ public class TestTiesDbService {
             verify(_mockCallbackUtils)
                     .executeRequest(
                             argThat(req -> httpRequestMatcher(
-                                    job.getId(),
+                                    _mockPropertiesUtil.getExportedJobId(job.getId()),
                                     BatchJobStatusType.COMPLETE,
                                     job.getMedia().iterator().next(),
                                     url,
@@ -454,7 +458,7 @@ public class TestTiesDbService {
         verify(_mockCallbackUtils)
                 .executeRequest(
                         argThat(req -> httpRequestMatcher(
-                                job.getId(),
+                                _mockPropertiesUtil.getExportedJobId(job.getId()),
                                 BatchJobStatusType.COMPLETE,
                                 job.getMedia().iterator().next(),
                                 url,
@@ -519,7 +523,7 @@ public class TestTiesDbService {
         verify(_mockCallbackUtils)
                 .executeRequest(
                         argThat(req -> httpRequestMatcher(
-                                job.getId(),
+                                _mockPropertiesUtil.getExportedJobId(job.getId()),
                                 BatchJobStatusType.COMPLETE,
                                 job.getMedia().iterator().next(),
                                 url,
@@ -584,7 +588,7 @@ public class TestTiesDbService {
         verify(_mockCallbackUtils)
                 .executeRequest(
                         argThat(req -> httpRequestMatcher(
-                                job.getId(),
+                                _mockPropertiesUtil.getExportedJobId(job.getId()),
                                 BatchJobStatusType.COMPLETE,
                                 media,
                                 url,
@@ -618,8 +622,10 @@ public class TestTiesDbService {
         var outputObjectLocation = URI.create("http://localhost:321/asdf");
         var outputSha = "ed2e2a154b4bf6802c3f418a64488b7bf3f734fa9ebfd568cf302ae4e8f4c3bb";
 
+        String jobId = _mockPropertiesUtil.getExportedJobId(job.getId());
+        
         ArgumentMatcher<HttpUriRequest> action1Matcher = request -> httpRequestMatcher(
-                job.getId(),
+                jobId,
                 BatchJobStatusType.COMPLETE_WITH_ERRORS,
                 media,
                 url,
@@ -631,8 +637,9 @@ public class TestTiesDbService {
                 timeCompleted,
                 request);
 
+
         ArgumentMatcher<HttpUriRequest> action2Matcher = request -> httpRequestMatcher(
-                job.getId(),
+                jobId,
                 BatchJobStatusType.COMPLETE_WITH_ERRORS,
                 media,
                 url,
@@ -734,7 +741,7 @@ public class TestTiesDbService {
 
 
     private boolean httpRequestMatcher(
-            long jobId,
+            String jobId,
             BatchJobStatusType jobStatus,
             Media media,
             String tiesDbBaseUrl,
@@ -788,7 +795,7 @@ public class TestTiesDbService {
         if (!trackType.equals(dataObject.get("outputType").textValue())) {
             return false;
         }
-        if (jobId != dataObject.get("jobId").longValue()) {
+        if (!jobId.equals(dataObject.get("jobId").textValue())) {
             return false;
         }
         if (!outputUri.toString().equals(dataObject.get("outputUri").textValue())) {

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestTiesDbService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestTiesDbService.java
@@ -99,6 +99,9 @@ public class TestTiesDbService {
 
         when(_mockPropertiesUtil.getHttpCallbackRetryCount())
                 .thenReturn(3);
+
+        when(_mockPropertiesUtil.getHostName())
+                .thenReturn("localhost");
     }
 
 


### PR DESCRIPTION
The job id presented to external entities is now a string that consists of the hostname of the MPF instance and the integer job id. Internally, the job id is still represented as an int. However, REST calls will now use the string form of the job id.

**Issues:**

- https://github.com/openmpf/openmpf/issues/1282

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/1470)
<!-- Reviewable:end -->
