### PR TITLE
Add FrameTimeInfo when job provides media metadata

### DIFF
--- a/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/mediainspection/MediaMetadataValidator.java
+++ b/trunk/workflow-manager/src/main/java/org/mitre/mpf/wfm/camel/operations/mediainspection/MediaMetadataValidator.java
@@ -32,6 +32,7 @@ import org.mitre.mpf.wfm.data.InProgressBatchJobsService;
 import org.mitre.mpf.wfm.data.entities.persistent.Media;
 import org.mitre.mpf.wfm.enums.IssueCodes;
 import org.mitre.mpf.wfm.enums.MediaType;
+import org.mitre.mpf.wfm.util.FrameTimeInfo;
 import org.mitre.mpf.wfm.util.MediaTypeUtils;
 import org.mitre.mpf.wfm.util.PngDefry;
 import org.mitre.mpf.wfm.util.TextUtils;
@@ -116,6 +117,8 @@ public class MediaMetadataValidator {
                     }
                     if (!missingVideoMetadata) {
                         checkMetadataTypes(mediaMetadata, REQUIRED_VIDEO_METADATA, true);
+                        _inProgressJobs.addFrameTimeInfo(jobId, mediaId,
+                                                         getFrameTimeInfo(mediaMetadata));
                         length = Integer.parseInt(mediaMetadata.get("FRAME_COUNT"));
                         break;
                     }
@@ -239,5 +242,18 @@ public class MediaMetadataValidator {
 
     private static boolean isBoolean(String value) {
         return value.equalsIgnoreCase("TRUE") || value.equalsIgnoreCase("FALSE");
+    }
+
+
+    private static FrameTimeInfo getFrameTimeInfo(Map<String, String> mediaMetadata) {
+        boolean hasConstantFrameRate = Boolean.parseBoolean(
+                mediaMetadata.get("HAS_CONSTANT_FRAME_RATE"));
+        double fps = Double.parseDouble(mediaMetadata.get("FPS"));
+        if (hasConstantFrameRate) {
+            return FrameTimeInfo.forConstantFrameRate(fps, 0, false);
+        }
+        else {
+            return FrameTimeInfo.forVariableFrameRateWithEstimatedTimes(fps);
+        }
     }
 }

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camel/operations/mediainspection/TestMediaMetadataValidator.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camel/operations/mediainspection/TestMediaMetadataValidator.java
@@ -34,6 +34,8 @@ import org.mitre.mpf.wfm.data.InProgressBatchJobsService;
 import org.mitre.mpf.wfm.data.entities.persistent.Media;
 import org.mitre.mpf.wfm.enums.IssueCodes;
 import org.mitre.mpf.wfm.enums.MediaType;
+import org.mitre.mpf.wfm.util.FrameTimeInfo;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -41,8 +43,7 @@ import org.mockito.MockitoAnnotations;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class TestMediaMetadataValidator {
@@ -101,6 +102,14 @@ public class TestMediaMetadataValidator {
                 "DURATION", "3",
                 "ROTATION", "0"),
                 MediaType.VIDEO, 90, Set.of());
+
+        var frameTimeInfoCaptor = ArgumentCaptor.forClass(FrameTimeInfo.class);
+        verify(_mockInProgressJobs)
+                .addFrameTimeInfo(eq(123L), eq(321L), frameTimeInfoCaptor.capture());
+        var frameTimeInfo = frameTimeInfoCaptor.getValue();
+        assertFalse(frameTimeInfo.hasConstantFrameRate());
+        assertTrue(frameTimeInfo.requiresTimeEstimation());
+        assertEquals(1_000, frameTimeInfo.getFrameTimeMs(30));
     }
 
     @Test


### PR DESCRIPTION
**Issues:**
- https://github.com/openmpf/openmpf/issues/1498

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/1499)
<!-- Reviewable:end -->
