### PR TITLE
Hotfix/byte buddy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
             <url>https://maven-us.nuxeo.org/nexus/content/repositories/vendor-releases/</url>
         </repository>
         <repository>
-            <id>mvnrepository.com-public-releases</id>
-            <name>mvnrepository.com</name>
+            <id>repository.mapr.com-public-releases</id>
+            <name>repository.mapr.com</name>
             <url>https://repository.mapr.com/nexus/content/groups/mapr-public/releases/</url>
         </repository>
     </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
             <name>nexus-vendor-releases</name>
             <url>https://maven-us.nuxeo.org/nexus/content/repositories/vendor-releases/</url>
         </repository>
+        <repository>
+            <id>mvnrepository.com-public-releases</id>
+            <name>mvnrepository-public-releases</name>
+            <url>https://repository.mapr.com/nexus/content/groups/mapr-public/releases/</url>
+        </repository>
     </repositories>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -75,13 +75,8 @@
     <repositories>
         <repository>
             <id>maven-us.nuxeo.org-vendor-releases</id>
-            <name>maven-us.nuxeo.org</name>
+            <name>nexus-vendor-releases</name>
             <url>https://maven-us.nuxeo.org/nexus/content/repositories/vendor-releases/</url>
-        </repository>
-        <repository>
-            <id>repository.mapr.com-public-releases</id>
-            <name>repository.mapr.com</name>
-            <url>https://repository.mapr.com/nexus/content/groups/mapr-public/releases/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,12 @@
 
     <repositories>
         <repository>
-            <id>maven-us.nuxeo.org-vendor-releases</id>
-            <name>nexus-vendor-releases</name>
+            <id>nuxeo-releases</id>
             <url>https://maven-us.nuxeo.org/nexus/content/repositories/vendor-releases/</url>
+        </repository>
+        <repository>
+            <id>mapr-releases</id>
+            <url>https://repository.mapr.com/nexus/content/groups/mapr-public/releases/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,12 @@
     <repositories>
         <repository>
             <id>maven-us.nuxeo.org-vendor-releases</id>
-            <name>nexus-vendor-releases</name>
+            <name>maven-us.nuxeo.org</name>
             <url>https://maven-us.nuxeo.org/nexus/content/repositories/vendor-releases/</url>
         </repository>
         <repository>
             <id>mvnrepository.com-public-releases</id>
-            <name>mvnrepository-public-releases</name>
+            <name>mvnrepository.com</name>
             <url>https://repository.mapr.com/nexus/content/groups/mapr-public/releases/</url>
         </repository>
     </repositories>

--- a/trunk/protobuf/pom.xml
+++ b/trunk/protobuf/pom.xml
@@ -51,6 +51,13 @@
         </dependency>
     </dependencies>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>mapr-releases</id>
+            <url>https://repository.mapr.com/nexus/content/groups/mapr-public/releases/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <resources>
         </resources>

--- a/trunk/protobuf/pom.xml
+++ b/trunk/protobuf/pom.xml
@@ -51,13 +51,6 @@
         </dependency>
     </dependencies>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>mapr-releases</id>
-            <url>https://repository.mapr.com/nexus/content/groups/mapr-public/releases/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <build>
         <resources>
         </resources>


### PR DESCRIPTION
**Issues:**

Fix the following error that occurs on a clean build on some host networks:

```
Could not transfer artifact net.bytebuddy:byte-buddy:jar:1.10.17 from/to central (https://repo.maven.apache.org/maven2): Connection timed out -> [Help 1]
```

**Related PRs:**

- https://github.com/openmpf/openmpf-docker/pull/180

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/1622)
<!-- Reviewable:end -->
