### PR TITLE
Hf merge/byte buddy version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
 
         <!-- Version numbers that are used more than once. -->
         <spring.framework.version>5.3.20</spring.framework.version>
-        <hibernate.framework.version>5.4.24.Final</hibernate.framework.version>
-        <hibernate.validator.version>5.4.2.Final</hibernate.validator.version>
+        <hibernate.framework.version>5.6.14.Final</hibernate.framework.version>
+        <hibernate.validator.version>5.4.3.Final</hibernate.validator.version>
         <camel.framework.version>2.24.0</camel.framework.version>
         <activemq.framework.version>5.15.9</activemq.framework.version>
         <javasimon.version>4.1.1</javasimon.version>
@@ -105,7 +105,7 @@
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <commons.lang3.version>3.10</commons.lang3.version>
         <tika.core.version>1.28.1</tika.core.version>
-        <mockito.core.version>2.26.0</mockito.core.version>
+        <mockito.core.version>4.9.0</mockito.core.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <google.protobuf.version>3.16.1</google.protobuf.version>
         <springfox.swagger.version>3.0.0</springfox.swagger.version>
@@ -117,6 +117,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <tomcat.servlet.api.version>7.0.72</tomcat.servlet.api.version>
         <guava.version>27.0.1-jre</guava.version>
+        <byte.buddy.version>1.12.18</byte.buddy.version>
 
         <!-- The C++ SDK install location can be changed by setting the MPF_SDK_INSTALL_PATH environment variable.  -->
         <components.build.script>${project.basedir}/../../openmpf-build-tools/build-openmpf-components/build_components.py</components.build.script>

--- a/trunk/markup/pom.xml
+++ b/trunk/markup/pom.xml
@@ -202,8 +202,4 @@
             </build>
         </profile>
     </profiles>
-
-    <pluginRepositories>
-
-    </pluginRepositories>
 </project>

--- a/trunk/mpf-system-tests/pom.xml
+++ b/trunk/mpf-system-tests/pom.xml
@@ -100,10 +100,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-servlet-api</artifactId>
             <version>${tomcat.servlet.api.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${byte.buddy.version}</version>
         </dependency>
     </dependencies>
 

--- a/trunk/node-manager/pom.xml
+++ b/trunk/node-manager/pom.xml
@@ -173,6 +173,12 @@
             <version>${jackson.version}</version>
         </dependency>
         <!-- / added for Jackson -->
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${byte.buddy.version}</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/trunk/node-manager/src/test/java/org/mitre/mpf/nms/streaming/ITStreamingJob.java
+++ b/trunk/node-manager/src/test/java/org/mitre/mpf/nms/streaming/ITStreamingJob.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/trunk/node-manager/src/test/java/org/mitre/mpf/nms/streaming/TestChildStreamingJobManager.java
+++ b/trunk/node-manager/src/test/java/org/mitre/mpf/nms/streaming/TestChildStreamingJobManager.java
@@ -26,6 +26,7 @@
 
 package org.mitre.mpf.nms.streaming;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.nms.ChannelNode;
@@ -40,10 +41,12 @@ import org.mockito.MockitoAnnotations;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class TestChildStreamingJobManager {
+
+	private AutoCloseable _closeable;
 
 	@InjectMocks
 	private ChildStreamingJobManager _childStreamingJobManager;
@@ -57,7 +60,13 @@ public class TestChildStreamingJobManager {
 
 	@Before
 	public void init() {
-		MockitoAnnotations.initMocks(this);
+		_closeable = MockitoAnnotations.openMocks(this);
+	}
+
+
+	@After
+	public void close() throws Exception {
+		_closeable.close();
 	}
 
 

--- a/trunk/node-manager/src/test/java/org/mitre/mpf/nms/streaming/TestMasterStreamingJobManager.java
+++ b/trunk/node-manager/src/test/java/org/mitre/mpf/nms/streaming/TestMasterStreamingJobManager.java
@@ -26,6 +26,7 @@
 
 package org.mitre.mpf.nms.streaming;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.nms.ChannelNode;
@@ -48,6 +49,8 @@ import static org.mockito.Mockito.*;
 
 public class TestMasterStreamingJobManager {
 
+	private AutoCloseable _closeable;
+
 	@InjectMocks
 	private MasterStreamingJobManager _streamingJobManager;
 
@@ -58,9 +61,13 @@ public class TestMasterStreamingJobManager {
 
 	@Before
 	public void init() {
-		MockitoAnnotations.initMocks(this);
+		_closeable = MockitoAnnotations.openMocks(this);
 	}
 
+	@After
+	public void close() throws Exception {
+		_closeable.close();
+	}
 
 	@Test
 	public void jobsStartOnNodeWithMinJobs() {

--- a/trunk/video-overlay/CMakeLists.txt
+++ b/trunk/video-overlay/CMakeLists.txt
@@ -28,6 +28,7 @@
 # openmpf-projects/openmpf/trunk/CMakeLists.txt.
 
 project(VideoOverlay)
+set(CMAKE_CXX_STANDARD 17)
 aux_source_directory(./src/main/cpp SRC)
 
 find_package(OpenCV 4.5.5 EXACT REQUIRED PATHS /opt/opencv-4.5.5 COMPONENTS opencv_core opencv_freetype)

--- a/trunk/workflow-manager/pom.xml
+++ b/trunk/workflow-manager/pom.xml
@@ -471,7 +471,6 @@
         </dependency>
         <!-- / added for Jackson -->
 
-
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
@@ -584,6 +583,12 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${byte.buddy.version}</version>
         </dependency>
     </dependencies>
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/mvc/TestControllerExceptionHandler.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/mvc/TestControllerExceptionHandler.java
@@ -26,6 +26,7 @@
 
 package org.mitre.mpf.mvc;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.rest.api.MessageModel;
@@ -44,6 +45,8 @@ import static org.mockito.Mockito.when;
 
 public class TestControllerExceptionHandler {
 
+    private AutoCloseable _closeable;
+
     private ControllerUncaughtExceptionHandler _handler;
 
     @Mock
@@ -55,13 +58,17 @@ public class TestControllerExceptionHandler {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
         _handler = new ControllerUncaughtExceptionHandler();
 
         when(_mockRequest.getHeaders("Accept"))
                 .thenReturn(Collections.emptyEnumeration());
     }
 
+    @After
+    public void close() throws Exception {
+	_closeable.close();
+    }
 
 
     @Test

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/mvc/controller/TestAdminComponentRegistrationController.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/mvc/controller/TestAdminComponentRegistrationController.java
@@ -26,6 +26,7 @@
 
 package org.mitre.mpf.mvc.controller;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,6 +52,8 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class TestAdminComponentRegistrationController {
+
+    private AutoCloseable _closeable;
 
     @InjectMocks
     private AdminComponentRegistrationController _controller;
@@ -80,7 +83,7 @@ public class TestAdminComponentRegistrationController {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
         _testModel = new RegisterComponentModel();
         _testModel.setPackageFileName(_testPackageName);
         _testModel.setComponentName(_testComponentName);
@@ -96,6 +99,11 @@ public class TestAdminComponentRegistrationController {
 
         when(_mockProperties.getUploadedComponentsDirectory())
                 .thenReturn(_tempFolder.getRoot());
+    }
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
     @Test
@@ -357,7 +365,7 @@ public class TestAdminComponentRegistrationController {
 
         assertEquals(HttpStatus.OK, result.getStatusCode());
         verify(mockFile)
-                .transferTo(notNull(File.class));
+                .transferTo((File)notNull());
 
     }
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camel/TestDlqRouteBuilder.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camel/TestDlqRouteBuilder.java
@@ -48,7 +48,7 @@ import javax.jms.*;
 import java.util.Queue;
 import java.util.*;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -91,6 +91,8 @@ public class TestDlqRouteBuilder {
 
     private static int runId = -1;
 
+    private AutoCloseable closeable;
+
     private CamelContext camelContext;
     private ConnectionFactory connectionFactory;
     private ActiveMQConnection connection;
@@ -101,7 +103,7 @@ public class TestDlqRouteBuilder {
 
     @Before
     public void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         SimpleRegistry simpleRegistry = new SimpleRegistry();
         simpleRegistry.put(DetectionDeadLetterProcessor.REF, mockDetectionDeadLetterProcessor);
@@ -147,6 +149,8 @@ public class TestDlqRouteBuilder {
             connection.stop();
             connection = null;
         }
+
+        closeable.close();
     }
 
     private void removeQueues() {

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camel/operations/mediainspection/TestMediaMetadataValidator.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camel/operations/mediainspection/TestMediaMetadataValidator.java
@@ -27,6 +27,8 @@
 package org.mitre.mpf.wfm.camel.operations.mediainspection;
 
 import com.google.common.collect.ImmutableMap;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.test.TestUtil;
@@ -48,6 +50,8 @@ import static org.mockito.Mockito.*;
 
 public class TestMediaMetadataValidator {
 
+    private AutoCloseable _closeable;
+
     @InjectMocks
     private MediaMetadataValidator _mediaMetadataValidator;
 
@@ -57,7 +61,12 @@ public class TestMediaMetadataValidator {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
     @Test

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/MediaTestUtil.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/MediaTestUtil.java
@@ -28,7 +28,6 @@
 package org.mitre.mpf.wfm.camelOps;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultMessage;
@@ -38,7 +37,7 @@ import org.mitre.mpf.wfm.data.entities.persistent.MediaImpl;
 import org.mitre.mpf.wfm.enums.MpfHeaders;
 
 import static org.mitre.mpf.test.TestUtil.nonBlank;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 public class MediaTestUtil {

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/TestDetectionResponseProcessor.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/TestDetectionResponseProcessor.java
@@ -29,6 +29,7 @@ package org.mitre.mpf.wfm.camelOps;
 import org.apache.camel.Exchange;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,6 +60,8 @@ import static org.mockito.Mockito.*;
 
 
 public class TestDetectionResponseProcessor {
+
+    private AutoCloseable _closeable;
 
     @Mock
     private PipelineService mockPipelineService;
@@ -98,7 +101,7 @@ public class TestDetectionResponseProcessor {
     @Before
     public void init() {
 
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
 
         detectionResponseProcessor = new DetectionResponseProcessor(
                 mockAggregateJobPropertiesUtil,
@@ -160,7 +163,11 @@ public class TestDetectionResponseProcessor {
 
         when(mockAggregateJobPropertiesUtil.getValue(MpfConstants.CONFIDENCE_THRESHOLD_PROPERTY, job, media, action))
                 .thenReturn(String.valueOf(0.1));
+    }
 
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
     @Test

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/TestMarkupResponseProcessor.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/TestMarkupResponseProcessor.java
@@ -27,6 +27,7 @@
 package org.mitre.mpf.wfm.camelOps;
 
 import org.apache.camel.Exchange;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.test.TestUtil;
@@ -53,6 +54,8 @@ import static org.mockito.Mockito.*;
 
 public class TestMarkupResponseProcessor {
 
+    private AutoCloseable _closeable;
+
     @InjectMocks
     private MarkupResponseProcessor _markupResponseProcessor;
 
@@ -69,8 +72,15 @@ public class TestMarkupResponseProcessor {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
     }
+
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
+    }
+
 
     @Test
     public void testMarkupResponse() {

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/TestMediaInspectionSplitter.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/TestMediaInspectionSplitter.java
@@ -30,6 +30,7 @@ import org.apache.camel.Message;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.DefaultExchange;
 import org.apache.camel.impl.DefaultMessage;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.test.TestUtil;
@@ -54,6 +55,8 @@ import static org.mockito.Mockito.when;
 
 public class TestMediaInspectionSplitter {
 
+    private AutoCloseable closeable;
+
     @InjectMocks
     private MediaInspectionSplitter mediaInspectionSplitter;
 
@@ -62,7 +65,13 @@ public class TestMediaInspectionSplitter {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+
+    @After
+    public void close() throws Exception {
+        closeable.close();
     }
 
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/TestRemoteMediaProcessor.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/camelOps/TestRemoteMediaProcessor.java
@@ -28,7 +28,6 @@ package org.mitre.mpf.wfm.camelOps;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -65,13 +64,15 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mitre.mpf.test.TestUtil.nonBlank;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 public class TestRemoteMediaProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(TestRemoteMediaProcessor.class);
     private static final int MINUTES = 1000*60; // 1000 milliseconds/second & 60 seconds/minute.
     private static final String EXT_IMG = "http://localhost:4587/test-image.jpg";
+
+    private AutoCloseable _closeable;
 
     private RemoteMediaProcessor _remoteMediaProcessor;
 
@@ -124,7 +125,7 @@ public class TestRemoteMediaProcessor {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
         when(_mockPropertiesUtil.getRemoteMediaDownloadRetries())
                 .thenReturn(3);
 
@@ -134,6 +135,12 @@ public class TestRemoteMediaProcessor {
         _remoteMediaProcessor = new RemoteMediaProcessor(
                 _mockInProgressJobs, null, _mockPropertiesUtil,
                 new AggregateJobPropertiesUtil(_mockPropertiesUtil, mock(WorkflowPropertyService.class)));
+    }
+
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestCensorPropertiesService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestCensorPropertiesService.java
@@ -29,6 +29,7 @@ package org.mitre.mpf.wfm.service;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.wfm.util.PropertiesUtil;
@@ -45,6 +46,8 @@ import static org.mockito.Mockito.when;
 
 public class TestCensorPropertiesService {
 
+    private AutoCloseable _closeable;
+
     @InjectMocks
     private CensorPropertiesService _censorPropertiesService;
 
@@ -53,7 +56,13 @@ public class TestCensorPropertiesService {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
+    }
+
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestStorageService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestStorageService.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.interop.JsonIssueDetails;
@@ -61,6 +62,8 @@ import static org.mockito.Mockito.*;
 
 public class TestStorageService {
 
+    private AutoCloseable _closeable;
+
     @InjectMocks
     private StorageService _storageService;
 
@@ -90,13 +93,17 @@ public class TestStorageService {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
         when(_mockPropertiesUtil.getJobIdFromExportedId(TEST_EXPORTED_JOB_ID))
                 .thenReturn(TEST_INTERNAL_JOB_ID);
         when(_mockOutputObject.getJobId())
                 .thenReturn(TEST_EXPORTED_JOB_ID);
     }
 
+    @After
+    public void close() throws Exception {
+        _closeable.close();
+    }
 
     @Test
     public void S3BackendHasHigherPriorityThanNginx() throws IOException, StorageException {
@@ -115,7 +122,6 @@ public class TestStorageService {
                 .store(any(JsonOutputObject.class), any());
     }
 
-
     @Test
     public void canStoreOutputObjectRemotely() throws IOException, StorageException {
 
@@ -128,7 +134,7 @@ public class TestStorageService {
         URI result = _storageService.store(_mockOutputObject, new MutableObject<>());
         assertEquals(TEST_REMOTE_URI, result);
 
-        verifyZeroInteractions(_mockLocalBackend);
+        verifyNoInteractions(_mockLocalBackend);
         verifyNoInProgressJobWarnings();
     }
 
@@ -235,7 +241,7 @@ public class TestStorageService {
         Table<Integer, Integer, URI> result = _storageService.storeArtifacts(request);
         assertEquals(expectedResults, result);
 
-        verifyZeroInteractions(_mockLocalBackend);
+        verifyNoInteractions(_mockLocalBackend);
         verifyNoInProgressJobWarnings();
     }
 
@@ -309,7 +315,7 @@ public class TestStorageService {
         Table<Integer, Integer, URI> result = _storageService.storeArtifacts(request);
         assertEquals(expectedResults, result);
 
-        verifyZeroInteractions(_mockLocalBackend);
+        verifyNoInteractions(_mockLocalBackend);
         verifyNoInProgressJobWarnings();
     }
 
@@ -383,7 +389,7 @@ public class TestStorageService {
                 .store(markup);
 
         verifyNoMarkupError(markup);
-        verifyZeroInteractions(_mockLocalBackend);
+        verifyNoInteractions(_mockLocalBackend);
         verifyNoInProgressJobWarnings();
     }
 
@@ -463,7 +469,7 @@ public class TestStorageService {
 
         verify(derivativeMedia).setStorageUri(TEST_REMOTE_URI.toString());
 
-        verifyZeroInteractions(_mockLocalBackend);
+        verifyNoInteractions(_mockLocalBackend);
         verifyNoInProgressJobWarnings();
     }
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestStreamingJobMessageSender.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestStreamingJobMessageSender.java
@@ -28,6 +28,7 @@ package org.mitre.mpf.wfm.service;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.nms.MasterNode;
@@ -58,6 +59,8 @@ import static org.mockito.Mockito.when;
 
 public class TestStreamingJobMessageSender {
 
+    private AutoCloseable _closeable;
+
     private StreamingJobMessageSenderImpl _messageSender;
 
     @Mock
@@ -75,11 +78,17 @@ public class TestStreamingJobMessageSender {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
         AggregateJobPropertiesUtil aggregateJobPropertiesUtil
                 = new AggregateJobPropertiesUtil(_mockProperties, _mockWorkflowPropertyService);
         _messageSender = new StreamingJobMessageSenderImpl(_mockProperties, aggregateJobPropertiesUtil,
                                                            _mockMasterNode, _mockServiceManager);
+    }
+
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestTiesDbService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/TestTiesDbService.java
@@ -34,6 +34,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -68,6 +69,8 @@ public class TestTiesDbService {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestTiesDbService.class);
 
+    private AutoCloseable _closeable;
+
     @Mock
     private PropertiesUtil _mockPropertiesUtil;
 
@@ -92,7 +95,7 @@ public class TestTiesDbService {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
         _tiesDbService = new TiesDbService(_mockPropertiesUtil, _mockAggregateJobPropertiesUtil,
                                            _objectMapper, _mockCallbackUtils, _mockJobRequestDao);
 
@@ -113,6 +116,10 @@ public class TestTiesDbService {
 
     }
 
+    @After
+    public void close() throws Exception {
+        _closeable.close();
+    }
 
     @Test
     public void testAddAssertions() {

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestAddComponentService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestAddComponentService.java
@@ -28,6 +28,8 @@ package org.mitre.mpf.wfm.service.component;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,6 +67,8 @@ public class TestAddComponentService {
 
     private AddComponentServiceImpl _addComponentService;
 
+    private AutoCloseable _closeable;
+
     @Mock
     private PropertiesUtil _mockPropertiesUtil;
 
@@ -99,12 +103,17 @@ public class TestAddComponentService {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
 
         _addComponentService = new AddComponentServiceImpl(
                 _mockPropertiesUtil, _mockPipelineService, Optional.of(_mockNodeManager),
                 Optional.of(_mockStreamingServiceManager), _mockDeploymentService, _mockStateService,
                 _mockDescriptorValidator, null, _mockRemoveComponentService, _mockObjectMapper);
+    }
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
     @Test
@@ -385,7 +394,7 @@ public class TestAddComponentService {
         boolean wasModified = _addComponentService.registerUnmanagedComponent(descriptor);
         assertTrue(wasModified);
 
-        verifyZeroInteractions(_mockRemoveComponentService, _mockNodeManager);
+        verifyNoInteractions(_mockRemoveComponentService, _mockNodeManager);
         verifySuccessfullyAddedUnmanagedComponent(descriptor);
     }
 
@@ -437,7 +446,7 @@ public class TestAddComponentService {
         boolean wasModified = _addComponentService.registerUnmanagedComponent(newDescriptor);
         assertTrue(wasModified);
 
-        verifyZeroInteractions(_mockNodeManager);
+        verifyNoInteractions(_mockNodeManager);
         verify(_mockRemoveComponentService)
                 .removeComponent(COMPONENT_NAME);
 
@@ -484,7 +493,7 @@ public class TestAddComponentService {
         assertFalse(wasModified);
 
 
-        verifyZeroInteractions(_mockRemoveComponentService, _mockDescriptorValidator,
+        verifyNoInteractions(_mockRemoveComponentService, _mockDescriptorValidator,
                                _mockPipelineService, _mockNodeManager);
 
         verify(_mockObjectMapper, never())
@@ -526,7 +535,7 @@ public class TestAddComponentService {
         catch (InvalidComponentDescriptorException ignored) {
         }
 
-        verifyZeroInteractions(_mockObjectMapper);
+        verifyNoInteractions(_mockObjectMapper);
         verify(_mockStateService, never())
                 .update(any());
     }

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestComponentReRegisterService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestComponentReRegisterService.java
@@ -28,6 +28,7 @@ package org.mitre.mpf.wfm.service.component;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mitre.mpf.rest.api.component.ComponentState;
@@ -53,6 +54,8 @@ import static org.mitre.mpf.test.TestUtil.collectionContaining;
 import static org.mockito.Mockito.*;
 
 public class TestComponentReRegisterService {
+
+    private AutoCloseable _closeable;
 
     @InjectMocks
     private ComponentReRegisterServiceImpl _reRegisterService;
@@ -90,7 +93,7 @@ public class TestComponentReRegisterService {
         when(_mockPropertiesUtil.getUploadedComponentsDirectory())
                 .thenReturn(_componentUploadDir.toFile());
 
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
 
         _componentToReRegister = new RegisterComponentModel();
         _componentToReRegister.setFullUploadedFilePath(_packageToReRegisterPath.toString());
@@ -103,6 +106,12 @@ public class TestComponentReRegisterService {
 
         when(_mockAddComponentService.registerComponent(_packageToReRegister))
                 .thenReturn(_componentToReRegister);
+    }
+
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestComponentStateService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestComponentStateService.java
@@ -29,6 +29,7 @@ package org.mitre.mpf.wfm.service.component;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,6 +53,8 @@ import static org.mockito.Mockito.*;
 
 public class TestComponentStateService {
 
+    private AutoCloseable _closeable;
+
     @InjectMocks
     private ComponentStateServiceImpl _componentStateService;
 
@@ -69,7 +72,7 @@ public class TestComponentStateService {
 
     @Before
     public void init() throws IOException {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
 
         _testRegisterModel = new RegisterComponentModel();
         _testRegisterModel.setComponentName(_testComponentName);
@@ -89,6 +92,12 @@ public class TestComponentStateService {
 
         when(_mockProperties.getComponentInfoFile())
                 .thenReturn(mock(WritableResource.class));
+    }
+
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
 

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestRemoveComponentService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestRemoveComponentService.java
@@ -27,6 +27,7 @@
 package org.mitre.mpf.wfm.service.component;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,6 +62,8 @@ import static org.mockito.Mockito.*;
 
 public class TestRemoveComponentService {
 
+    private AutoCloseable _closeable;
+
     private RemoveComponentServiceImpl _removeComponentService;
 
     @Mock
@@ -86,11 +89,17 @@ public class TestRemoveComponentService {
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
 
         _removeComponentService = new RemoveComponentServiceImpl(
                 Optional.of(_mockNodeManager), Optional.of(_mockStreamingServiceManager), _mockDeploymentService,
                 _mockStateService, _mockPipelineService, _mockPropertiesUtil);
+    }
+
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
     }
 
     @Test
@@ -235,7 +244,7 @@ public class TestRemoveComponentService {
         verify(_mockPipelineService)
                 .deletePipeline("TEST PIPELINE");
 
-        verifyZeroInteractions(_mockNodeManager, _mockStreamingServiceManager, _mockDeploymentService);
+        verifyNoInteractions(_mockNodeManager, _mockStreamingServiceManager, _mockDeploymentService);
 
         assertTrue(Files.exists(otherPluginDir));
         assertFalse(Files.exists(testComponentDir));

--- a/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestStartupComponentRegistrationService.java
+++ b/trunk/workflow-manager/src/test/java/org/mitre/mpf/wfm/service/component/TestStartupComponentRegistrationService.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,11 +56,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mitre.mpf.test.TestUtil.collectionContaining;
 import static org.mitre.mpf.test.TestUtil.nonEmptyCollection;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class TestStartupComponentRegistrationService {
 
+    private AutoCloseable _closeable;
 
     private StartupComponentRegistrationServiceImpl _startupRegisterSvc;
 
@@ -85,7 +87,7 @@ public class TestStartupComponentRegistrationService {
 
     @Before
     public void init() throws IOException, ComponentRegistrationException {
-        MockitoAnnotations.initMocks(this);
+        _closeable = MockitoAnnotations.openMocks(this);
 
         _componentUploadDir.newFolder("test");
         _componentUploadDir.newFile("bad.bad");
@@ -113,6 +115,11 @@ public class TestStartupComponentRegistrationService {
                 });
     }
 
+
+    @After
+    public void close() throws Exception {
+        _closeable.close();
+    }
 
 
     @Test


### PR DESCRIPTION
**Issues:**

Fix the following error that occurs on a clean build on some host networks:

```
Could not transfer artifact net.bytebuddy:byte-buddy:jar:1.10.17 from/to central (https://repo.maven.apache.org/maven2): Connection timed out -> [Help 1]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf/1624)
<!-- Reviewable:end -->
